### PR TITLE
set `OC_BINARY_PATH` environment variable in workflow to fix issue #20

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -93,6 +93,9 @@ jobs:
           set -Eeuxo pipefail
           uv run pytest tests/workbenches
         working-directory: opendatahub-tests
+        env:
+          # https://github.com/jiridanek/rhoai-in-kind/issues/20
+          OC_BINARY_PATH: /usr/local/bin/oc
 
       - name: Collect logs
         run: ${PYTHON3} components/logs.py


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to explicitly set the path for the `oc` binary during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->