### PR TITLE
add rhods-notebooks namespace and Kubeflow Notebook Controller version to workbench configuration

### DIFF
--- a/components/07-dsc-dsci.yaml
+++ b/components/07-dsc-dsci.yaml
@@ -82,6 +82,8 @@ spec:
       managementState: Managed
     workbenches:
       managementState: Managed
+      # https://issues.redhat.com/browse/RHOAIENG-18420
+      workbenchNamespace: rhods-notebooks
     dashboard:
       managementState: Managed
     modelmeshserving:
@@ -94,7 +96,14 @@ spec:
       registriesNamespace: ""
       managementState: Removed
 status:
-  components: {}
+  components:
+    workbenches:
+      managementState: Managed
+      releases:
+        - name: Kubeflow Notebook Controller
+          repoUrl: 'https://github.com/kubeflow/kubeflow'
+          version: 1.10.0
+      workbenchNamespace: rhods-notebooks
   conditions:
     - lastHeartbeatTime: '2024-10-01T04:50:20Z'
       lastTransitionTime: '2024-09-30T15:30:24Z'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field to specify the namespace for workbenches in the Data Science Cluster configuration.
  * Status section now provides detailed information about the workbenches component, including management state, release details, and namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->