### PR TITLE
GHA - free disk space in mnt directory

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -49,6 +49,16 @@ jobs:
         with:
           python-version: '3.13'
 
+      # https://github.com/jiridanek/rhoai-in-kind/issues/10
+      # ERROR: very rarely, we end up with a full disk in mnt directory
+      - name: Free disk space and swapoff
+        run: |
+          df -h
+          sudo du -sh /mnt/*
+          sudo swapoff -a
+          sudo rm -rf /mnt/*
+          df -h
+
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1
       - name: Pre-pull the kind image

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -31,6 +31,16 @@ jobs:
         id: setup-python
         with:
           python-version: '3.13'
+    
+      # https://github.com/jiridanek/rhoai-in-kind/issues/10
+      # ERROR: very rarely, we end up with a full disk in mnt directory
+      - name: Free disk space and swapoff
+        run: |
+          df -h
+          sudo du -sh /mnt/*
+          sudo swapoff -a
+          sudo rm -rf /mnt/*
+          df -h
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -78,6 +78,16 @@ jobs:
         with:
           python-version: '3.13'
 
+      # https://github.com/jiridanek/rhoai-in-kind/issues/10
+      # ERROR: very rarely, we end up with a full disk in mnt directory
+      - name: Free disk space and swapoff
+        run: |
+          df -h
+          sudo du -sh /mnt/*
+          sudo swapoff -a
+          sudo rm -rf /mnt/*
+          df -h
+          
       # Pulling large images (pytorch, tensorflow) we are otherwise running out of disk apace
       - name: Relocate docker data dir
         run: |

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -87,7 +87,7 @@ jobs:
           sudo swapoff -a
           sudo rm -rf /mnt/*
           df -h
-          
+
       # Pulling large images (pytorch, tensorflow) we are otherwise running out of disk apace
       - name: Relocate docker data dir
         run: |


### PR DESCRIPTION
Fixes #10 
Adding a new step in GHA to free disk space in mnt directory, because there were some rare errors with full disk usage. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple GitHub Actions workflows to include a step that frees up disk space and disables swap, helping to prevent rare disk space exhaustion issues during workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->