### PR TITLE
ci: add workflow_dispatch inputs to override test repo/branch

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      test_repo:
+        description: 'odh-dashboard repo to check out (owner/name)'
+        default: 'opendatahub-io/odh-dashboard'
+      test_ref:
+        description: 'odh-dashboard branch/tag/SHA to check out'
+        default: 'v2.37.1-odh'
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
@@ -44,10 +51,12 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          repository: opendatahub-io/odh-dashboard
-          # Match the deployed dashboard image (components/04-odh-dashboard.yaml). `main` drifted;
-          # its npm-workspaces monorepo layout also broke the install below. See #47.
-          ref: v2.37.1-odh
+          # Defaults match the deployed dashboard image (components/04-odh-dashboard.yaml).
+          # `main` drifted; its npm-workspaces monorepo layout also broke the install below (#47).
+          # Override via workflow_dispatch inputs to test against a fork/branch (e.g. a PR still
+          # in review upstream) without editing this file - see #35.
+          repository: ${{ inputs.test_repo || 'opendatahub-io/odh-dashboard' }}
+          ref: ${{ inputs.test_ref || 'v2.37.1-odh' }}
           path: odh-dashboard
           # Full checkout (no sparse-checkout): odh-dashboard is an npm workspaces monorepo, so
           # `npm ci` at the root needs every workspace (backend, packages/*, frontend, ...) plus

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      test_repo:
+        description: 'opendatahub-tests repo to check out (owner/name)'
+        default: 'opendatahub-io/opendatahub-tests'
+      test_ref:
+        description: 'opendatahub-tests branch/tag/SHA to check out'
+        default: '94670b336c632ac2c0022b347444b687d9384327'
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
@@ -29,8 +36,10 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          repository: opendatahub-io/opendatahub-tests
-          ref: 94670b336c632ac2c0022b347444b687d9384327  # Sept 18, 2025 - last known working
+          # Default ref: Sept 18, 2025 - last known working. Override via workflow_dispatch
+          # inputs to test against a fork/branch without editing this file - see #35.
+          repository: ${{ inputs.test_repo || 'opendatahub-io/opendatahub-tests' }}
+          ref: ${{ inputs.test_ref || '94670b336c632ac2c0022b347444b687d9384327' }}
           path: opendatahub-tests
 
       # Otherwise we may end up with a random Python version?

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -67,8 +67,8 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: red-hat-data-services/ods-ci
-          ref: master
+          repository: jstourac/ods-ci
+          ref: elyraPipelineName
           path: ods-ci
 
       # Otherwise we may end up with a random Python version?

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      test_repo:
+        description: 'ods-ci repo to check out (owner/name)'
+        default: 'red-hat-data-services/ods-ci'
+      test_ref:
+        description: 'ods-ci branch/tag/SHA to check out'
+        default: 'release-2.25'
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
@@ -182,11 +189,13 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
-          repository: red-hat-data-services/ods-ci
-          # Track the rhoai-2.25 stable line to match our pinned deployment (workbench v1.36.0,
-          # dashboard v2.37.1-odh). master drifted: it requires extra test-variables and a
-          # "Hardware profile" spawner UI our dashboard doesn't render. See issues #42, #45.
-          ref: release-2.25
+          # Defaults track the rhoai-2.25 stable line to match our pinned deployment (workbench
+          # v1.36.0, dashboard v2.37.1-odh). master drifted: it requires extra test-variables and
+          # a "Hardware profile" spawner UI our dashboard doesn't render. See issues #42, #45.
+          # Override via workflow_dispatch inputs to test against a fork/branch without editing
+          # this file - see #35.
+          repository: ${{ inputs.test_repo || 'red-hat-data-services/ods-ci' }}
+          ref: ${{ inputs.test_ref || 'release-2.25' }}
           path: ods-ci
 
       # Otherwise we may end up with a random Python version?


### PR DESCRIPTION
## Summary

Replaces the throwaway personal-fork hack originally on this branch with a general `workflow_dispatch` input mechanism: each of the three CI workflows now accepts `test_repo` / `test_ref` to override which repo/branch of the vendored test suite (odh-dashboard, ods-ci, opendatahub-tests) gets checked out, without editing workflow files.

## Root cause

This PR originally hardcoded `repository: jstourac/ods-ci` / `ref: elyraPipelineName` directly into `rhoai-in-kind-with-ods-ci.yaml` so an external contributor (@jstourac) could validate an Elyra-pipeline-related ods-ci change against this repo's CI. CodeRabbit flagged two real problems with that approach: `ref: elyraPipelineName` is a literal string, not an interpolated variable (it only worked because a branch literally named that existed on the fork), and pointing CI at an unpinned personal fork/branch is a supply-chain risk. jstourac's own closing comment confirmed the one-off test had served its purpose and asked for the PR to be closed - instead of closing it, turned the underlying need (let a caller point CI at their own fork/branch) into a proper feature.

## Related issue

None filed; motivated by re-reviewing this stale PR.

## Test plan

- [x] `actionlint` on all three workflow files - only pre-existing, unrelated findings (a shellcheck style nit in ods-ci, a known artifact-name property gap in shiftleft).
- [ ] Manually trigger one workflow via `workflow_dispatch` with custom `test_repo`/`test_ref` and confirm the checkout step resolves them (triggered on this PR's branch, see comment below).
- [ ] Confirm this PR's own CI run (PR trigger, no dispatch inputs) still checks out the default repo/ref.

<details>
<summary>Plan</summary>

# Add workflow_dispatch inputs for custom test repo/branch overrides

## Context

PR #35 was a throwaway PR that temporarily hardcoded `jstourac/ods-ci` +
branch `elyraPipelineName` in the ods-ci workflow so an external contributor
could validate an Elyra change against this repo's CI. That approach is
brittle (literal branch name, supply-chain risk from unpinned fork) and
leaves a stale PR behind. The real fix is a proper `workflow_dispatch` input
mechanism so anyone can specify custom repos/branches at trigger time without
editing workflow files.

All three CI workflows check out exactly one external test repo each:

| Workflow | Default repo | Default ref | Checkout path |
|---|---|---|---|
| `rhoai-in-kind-with-cypress.yaml` | `opendatahub-io/odh-dashboard` | `v2.37.1-odh` | `odh-dashboard` |
| `rhoai-in-kind-with-ods-ci.yaml` | `red-hat-data-services/ods-ci` | `release-2.25` | `ods-ci` |
| `rhoai-in-kind-with-odh-tests-shiftleft.yaml` | `opendatahub-io/opendatahub-tests` | `94670b33...` (SHA) | `opendatahub-tests` |

All three share identical `on:` triggers (pull_request, push to main,
workflow_dispatch with no inputs, daily cron). None uses reusable workflows.

## Design

Add two `workflow_dispatch` inputs to each workflow — `test_repo` and
`test_ref` — that default to the current hardcoded values. The checkout
step uses `${{ inputs.test_repo || '<default>' }}` so PR/push/cron
triggers (where `inputs.*` is empty) keep the existing behavior.

### Per-workflow inputs

**cypress** (`rhoai-in-kind-with-cypress.yaml`):
```yaml
workflow_dispatch:
  inputs:
    test_repo:
      description: 'odh-dashboard repo (owner/name)'
      default: 'opendatahub-io/odh-dashboard'
    test_ref:
      description: 'odh-dashboard branch/tag/SHA'
      default: 'v2.37.1-odh'
```

**ods-ci** (`rhoai-in-kind-with-ods-ci.yaml`):
```yaml
workflow_dispatch:
  inputs:
    test_repo:
      description: 'ods-ci repo (owner/name)'
      default: 'red-hat-data-services/ods-ci'
    test_ref:
      description: 'ods-ci branch/tag/SHA'
      default: 'release-2.25'
```

**odh-tests-shiftleft** (`rhoai-in-kind-with-odh-tests-shiftleft.yaml`):
```yaml
workflow_dispatch:
  inputs:
    test_repo:
      description: 'opendatahub-tests repo (owner/name)'
      default: 'opendatahub-io/opendatahub-tests'
    test_ref:
      description: 'opendatahub-tests branch/tag/SHA'
      default: '94670b336c632ac2c0022b347444b687d9384327'
```

### Checkout step change (same pattern in all three)

```yaml
- uses: actions/checkout@v7
  with:
    repository: ${{ inputs.test_repo || '<default-repo>' }}
    ref: ${{ inputs.test_ref || '<default-ref>' }}
    path: <existing-path>
```

The `|| '<default>'` fallback is critical — without it, non-dispatch
triggers (PR, push, cron) would get empty strings and fail.

### Naming consistency

Using generic `test_repo` / `test_ref` across all three (not
`ods_ci_repo`, `dashboard_repo`, etc.) keeps the interface uniform.
Each workflow only checks out one external repo, so there's no ambiguity
within a single workflow, and the `description:` field clarifies which
repo it refers to.

## Implementation steps

1. `git fetch origin jiridanek-patch-2elyraPipelineName` and check out
   that branch locally
2. Edit all three workflow files with the pattern above
3. Amend/replace the existing single commit on that branch (it's a
   throwaway commit with a nonsensical message)
4. Force-push to update PR #35

## Files to modify

- `.github/workflows/rhoai-in-kind-with-cypress.yaml` — `on:` block + checkout step
- `.github/workflows/rhoai-in-kind-with-ods-ci.yaml` — `on:` block + checkout step
- `.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml` — `on:` block + checkout step

## Verification

- `actionlint` on all three files
- Trigger one workflow manually via `gh workflow run` with custom
  `test_repo` / `test_ref` values and confirm the checkout step uses them
- Confirm PR/push triggers still use defaults (check a CI run on the PR
  itself — the checkout step log prints the repo+ref it resolved)

</details>

<details>
<summary>Trajectory</summary>

1. Reviewed PR #35 (open since 2025-08-05, authored via GitHub's UI patch flow): it hardcoded `jstourac/ods-ci` @ `elyraPipelineName` into the ods-ci workflow's checkout step, with CodeRabbit review comments flagging the literal-ref bug and the unpinned-fork supply-chain risk, and a closing comment from jstourac saying the test worked and asking for the PR to be closed.
2. Recognized this pointed to a real feature gap: no clean way to point any of the three CI workflows at a custom test-suite repo/branch without editing the workflow file each time.
3. Explored all three workflow files (`rhoai-in-kind-with-cypress.yaml`, `rhoai-in-kind-with-ods-ci.yaml`, `rhoai-in-kind-with-odh-tests-shiftleft.yaml`) to confirm each checks out exactly one external test repo, with identical `on:` triggers (pull_request, push to main, workflow_dispatch with no inputs, daily cron) and no reusable-workflow (`workflow_call`) pattern to hook into.
4. Designed a minimal-duplication approach: add `test_repo`/`test_ref` `workflow_dispatch` inputs (uniform names across all three workflows, since each only checks out one external repo) defaulting to the current pinned values, and change each checkout step's `repository`/`ref` to `${{ inputs.test_repo || '<default>' }}` / `${{ inputs.test_ref || '<default>' }}` so PR/push/cron triggers (where `inputs.*` is empty) are unaffected.
5. Checked out PR #35's branch (`jiridanek-patch-2elyraPipelineName`) locally; found it was 48 commits behind `main`. Attempted a rebase onto `main`, hit a merge conflict on the ods-ci workflow (expected, since the old commit's content was being fully replaced anyway); aborted the rebase and instead reset the branch to current `main`, since the old commit's content wasn't being kept.
6. Implemented the `workflow_dispatch` inputs and checkout-step changes in all three workflow files, with comments explaining the override mechanism and linking back to PR #35 for context.
7. Ran `actionlint` on all three files - two pre-existing findings only (a shellcheck style nit in ods-ci around line 234, and a known `artifact-name` property gap in shiftleft around line 133), both unrelated to this change.
8. Verified via `git status`/`git diff --stat` that only the three intended workflow files were modified.
9. Committed and force-pushed (with `--force-with-lease`) to `jiridanek-patch-2elyraPipelineName`, updating PR #35's title and description to reflect the new goal.

</details>
