### PR TITLE
Pin to rhoai-2.25 stable baseline; stabilize ods-ci, cypress, and shiftleft CI

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -39,10 +39,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: opendatahub-io/odh-dashboard
-          ref: main
+          # Match the deployed dashboard image (components/04-odh-dashboard.yaml). `main` drifted;
+          # its npm-workspaces monorepo layout also broke the install below. See #47.
+          ref: v2.37.1-odh
           path: odh-dashboard
-          sparse-checkout: |
-            frontend/
+          # Full checkout (no sparse-checkout): odh-dashboard is an npm workspaces monorepo, so
+          # `npm ci` at the root needs every workspace (backend, packages/*, frontend, ...) plus
+          # the single root package-lock.json to be present.
 
       # Otherwise we may end up with a random Python version?
       # https://github.com/jiridanek/rhoai-in-kind/issues/16
@@ -120,25 +123,12 @@ jobs:
       - name: Setup cypress
         run: |
           set -Eeuxo pipefail
-
-          # tput: No value for $TERM and no -T specified
-          #sudo apt-get update
-          #sudo apt-get install -y xterm ncurses-bin
-
-          # sudo apt install -y libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libxtst6 xauth xvfb
-
-          # > odh-dashboard@2.0.0 prepare
-          # > husky
-          #
-          # sh: 1: husky: not found
-          # npm error code 127
-          # npm error path /home/runner/work/rhoai-in-kind/rhoai-in-kind/odh-dashboard
-          # npm error command failed
-          # npm error command sh -c husky
-          npm install -g husky
-
-          npm --prefix frontend ci --prefer-offline --no-audit
-        working-directory: odh-dashboard/frontend
+          # odh-dashboard is an npm workspaces monorepo: install from the repo root so all
+          # workspaces (incl. frontend) and the cypress binary are set up. husky (a root
+          # devDependency) runs via the `prepare` script during install, so no global husky
+          # install is needed. See #47.
+          npm ci --prefer-offline --no-audit
+        working-directory: odh-dashboard
 
       - name: Run cypress
         run: |

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.25
+          - v1.36.0
 
         test_case:
           - "**/workbenches/testWorkbenchControlSuite.cy.ts"

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.23
+          - rhoai-2.25
 
         test_case:
           - "**/workbenches/testWorkbenchControlSuite.cy.ts"

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
+  # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46
   push:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # at 02:00

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -93,7 +93,10 @@ jobs:
       - name: Run workbenches tests
         run: |
           set -Eeuxo pipefail
-          uv run pytest tests/workbenches
+          # https://github.com/opendatahub-io/opendatahub-tests/blob/41e0d6fd4be365a083a3747a7037f70a3540b4e3/tests/workbenches/conftest.py#L44
+          # deselect: test_oauth_container_resource_customization asserts the oauth sidecar CPU
+          # request, but our remove-cpu-memory-requests Kyverno policy strips it here. See #48
+          uv run pytest tests/workbenches --deselect tests/workbenches/notebook-controller/test_spawning.py::TestNotebook::test_oauth_container_resource_customization
         working-directory: opendatahub-tests
         env:
           # https://github.com/jiridanek/rhoai-in-kind/issues/20

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: opendatahub-io/opendatahub-tests
-          ref: main
+          ref: 94670b336c632ac2c0022b347444b687d9384327  # Sept 17, 2025 - last known working
           path: opendatahub-tests
 
       # Otherwise we may end up with a random Python version?

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
+  # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46
   push:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # at 02:00

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.25
+          - v1.36.0
 
     steps:
 

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: opendatahub-io/opendatahub-tests
-          ref: 94670b336c632ac2c0022b347444b687d9384327  # Sept 17, 2025 - last known working
+          ref: 94670b336c632ac2c0022b347444b687d9384327  # Sept 18, 2025 - last known working
           path: opendatahub-tests
 
       # Otherwise we may end up with a random Python version?

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.23
+          - rhoai-2.25
 
     steps:
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.23
+          - rhoai-2.25
 
         test_case:
           - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         workbench_branch:
-          - rhoai-2.25
+          - v1.36.0
 
         test_case:
           - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
+  # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46
   push:
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * *' # at 02:00

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -68,7 +68,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: red-hat-data-services/ods-ci
-          ref: master
+          # Track the rhoai-2.25 stable line to match our pinned deployment (workbench v1.36.0,
+          # dashboard v2.37.1-odh). master drifted: it requires extra test-variables and a
+          # "Hardware profile" spawner UI our dashboard doesn't render. See issues #42, #45.
+          ref: release-2.25
           path: ods-ci
 
       # Otherwise we may end up with a random Python version?

--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ kind create cluster --config components/00-kind-cluster.yaml --image docker.io/k
 python3 components/deploy.py --workbench-branch=v1.36.0
 ```
 
+> **Apple Silicon (arm64) note:** the `api-extension` image is published for `amd64` only.
+> On an arm64 Podman machine it runs under QEMU emulation and crashes at startup with the Go
+> runtime error `lfstack.push invalid packing`. Either build it natively for arm64
+> (`podman build --platform linux/arm64 -t quay.io/jdanek/api-extension:latest -f components/api-extension/Dockerfile components/api-extension/` then `kind load docker-image quay.io/jdanek/api-extension:latest`),
+> or configure the Podman machine to use Rosetta 2 for amd64 images (faster, recommended):
+>
+> ```shell
+> podman machine ssh "sudo touch /etc/containers/enable-rosetta && sudo systemctl start rosetta-activation.service"
+> ```
+>
+> See [macOS Podman + Rosetta setup](https://github.com/opendatahub-io/notebooks/blob/main/docs/macos-podman-rosetta.md).
+
 What does it do? This, among other things, in order to setup argocd access
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ podman machine set --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
 kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
 
-python3 components/deploy.py --workbench-branch=rhoai-2.22
+python3 components/deploy.py --workbench-branch=rhoai-2.25
 ```
 
 What does it do? This, among other things, in order to setup argocd access
@@ -90,3 +90,12 @@ argocd cluster add kind-kind --yes
 kubectl apply -f components/03-kf-pipelines.yaml
 argocd app sync kf-pipelines
 ```
+
+### Troubleshooting
+
+Setting up the environment using this repo requires fast internet connection, otherwise things tend to timeout.
+
+If you're getting timeouts from `kubect apply`, increase the timeout encoded in the URL.
+
+If you're getting timeouts while syncing ArgoCD applications, try increasing the `git clone` timeout in components/01-argocd/gittimeoutconfig.yaml.
+We will have the ability to do shallow clones in ArgoCD 3.0.

--- a/README.md
+++ b/README.md
@@ -71,12 +71,15 @@ Therefore, what's missing from OpenShift and is required needs to be poly-filled
 
 Might get out-of-date, see .github/workflows/rhoai-in-kind.yaml for authoritative steps.
 
+For `rhoai-2.25`, use [notebooks tag v1.36.0](https://github.com/opendatahub-io/notebooks/releases/tag/v1.36.0).
+This is what went into the [corresponding ODH release](https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3351838012)
+
 ```shell
 podman machine set --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
 kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
 
-python3 components/deploy.py --workbench-branch=rhoai-2.25
+python3 components/deploy.py --workbench-branch=v1.36.0
 ```
 
 What does it do? This, among other things, in order to setup argocd access

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ argocd app sync kf-pipelines
 
 Setting up the environment using this repo requires fast internet connection, otherwise things tend to timeout.
 
-If you're getting timeouts from `kubect apply`, increase the timeout encoded in the URL.
+If you're getting timeouts from `kubectl apply`, increase the timeout encoded in the URL.
 
 If you're getting timeouts while syncing ArgoCD applications, try increasing the `git clone` timeout in components/01-argocd/gittimeoutconfig.yaml.
 We will have the ability to do shallow clones in ArgoCD 3.0.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,87 @@ If you're getting timeouts from `kubectl apply`, increase the timeout encoded in
 
 If you're getting timeouts while syncing ArgoCD applications, try increasing the `git clone` timeout in components/01-argocd/gittimeoutconfig.yaml.
 We will have the ability to do shallow clones in ArgoCD 3.0.
+
+### DNS: `*.sslip.io` hostnames don't resolve (macOS)
+
+Services are exposed under [sslip.io](https://sslip.io) wildcard hostnames such as
+`minio.apps.127.0.0.1.sslip.io`, which are supposed to resolve to `127.0.0.1`.
+If `curl -k https://minio.apps.127.0.0.1.sslip.io` hangs or `deploy.py` fails in
+`create_buckets()` with `NameResolutionError` / `EndpointConnectionError` — while
+the cluster gateway is actually up — the problem is host DNS resolution, not the
+cluster.
+
+Two common macOS causes:
+
+1. **A per-domain resolver in `/etc/resolver/` points at a local DNS that isn't running.**
+   A file like `/etc/resolver/127.0.0.1.sslip.io` containing `nameserver 127.0.0.1`
+   routes every `*.127.0.0.1.sslip.io` lookup to `127.0.0.1:53`. If you don't have a
+   local resolver (dnsmasq/CoreDNS) listening there, resolution fails.
+2. **DNS-rebinding protection** in Tailscale MagicDNS or some corporate/VPN resolvers,
+   which drops answers pointing to a loopback address.
+
+Diagnostic commands (macOS):
+
+```shell
+# What the system resolver (curl/python/boto3) actually returns — empty means it refuses the name
+dscacheutil -q host -a name minio.apps.127.0.0.1.sslip.io
+
+# Direct query, bypassing /etc/resolver overrides (sslip.io should answer 127.0.0.1)
+nslookup minio.apps.127.0.0.1.sslip.io
+
+# Inspect resolver scopes and per-domain nameservers
+scutil --dns
+ls -la /etc/resolver/ && cat /etc/resolver/*
+
+# Prove the gateway works by bypassing DNS entirely (403 from MinIO = reachable)
+curl -k --resolve minio.apps.127.0.0.1.sslip.io:443:127.0.0.1 https://minio.apps.127.0.0.1.sslip.io/
+
+# Is a local resolver actually listening on :53?
+sudo lsof -nP -iUDP:53 -iTCP:53
+```
+
+Fixes:
+
+- If you rely on a local sslip.io resolver, make sure it is running.
+- Otherwise remove the stale override so normal DNS (which resolves sslip.io to
+  `127.0.0.1`) is used, and flush the cache:
+
+  ```shell
+  sudo rm /etc/resolver/127.0.0.1.sslip.io
+  sudo dscacheutil -flushcache && sudo killall -HUP mDNSResponder
+  ```
+
+- If Tailscale is intercepting DNS: `tailscale set --accept-dns=false`.
+
+#### Local `sslip.io` resolver via dnsmasq (macOS)
+
+The most robust setup is a local dnsmasq that maps the whole wildcard to loopback —
+it works offline, is fast, and sidesteps rebinding filters. This is the setup this
+repo was developed with:
+
+```shell
+brew install dnsmasq
+
+# Homebrew's prefix differs by arch (/opt/homebrew on Apple Silicon, /usr/local on Intel).
+BREW_PREFIX="$(brew --prefix)"
+
+# 1. Map every *.127.0.0.1.sslip.io host to 127.0.0.1.
+#    `brew services` starts dnsmasq with `-7 "$BREW_PREFIX/etc/dnsmasq.d",*.conf`,
+#    so any *.conf here is loaded automatically (no conf-dir edit needed).
+echo 'address=/.127.0.0.1.sslip.io/127.0.0.1' > "$BREW_PREFIX/etc/dnsmasq.d/sslip.conf"
+
+# 2. Route *.127.0.0.1.sslip.io lookups to the local resolver
+echo 'nameserver 127.0.0.1' | sudo tee /etc/resolver/127.0.0.1.sslip.io
+
+# 3. Start dnsmasq (needs sudo to bind port 53)
+sudo brew services start dnsmasq
+```
+
+Verify:
+
+```shell
+dscacheutil -q host -a name minio.apps.127.0.0.1.sslip.io   # should print 127.0.0.1
+```
+
+The usual failure mode is simply that the dnsmasq service isn't running (e.g. after
+a reboot if it wasn't enabled): `sudo brew services start dnsmasq` fixes it.

--- a/README.md
+++ b/README.md
@@ -75,22 +75,38 @@ For `rhoai-2.25`, use [notebooks tag v1.36.0](https://github.com/opendatahub-io/
 This is what went into the [corresponding ODH release](https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3351838012)
 
 ```shell
-podman machine set --rootful --memory $((16 * 1024)) --cpus 4
+# On Apple Silicon, enable Rosetta so the VM can run the amd64-only images (see note below).
+# Rosetta is set via containers.conf (there is no `podman machine` CLI flag); it is the
+# default on recent Podman — check with `podman machine inspect --format '{{.Rosetta}}'`.
+# Enable it once if needed, before creating the machine:
+mkdir -p ~/.config/containers && printf '[machine]\nrosetta = true\n' >> ~/.config/containers/containers.conf
+
+podman machine init --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
 kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
 
 python3 components/deploy.py --workbench-branch=v1.36.0
 ```
 
-> **Apple Silicon (arm64) note:** the `api-extension` image is published for `amd64` only.
-> On an arm64 Podman machine it runs under QEMU emulation and crashes at startup with the Go
-> runtime error `lfstack.push invalid packing`. Either build it natively for arm64
-> (`podman build --platform linux/arm64 -t quay.io/jdanek/api-extension:latest -f components/api-extension/Dockerfile components/api-extension/` then `kind load docker-image quay.io/jdanek/api-extension:latest`),
-> or configure the Podman machine to use Rosetta 2 for amd64 images (faster, recommended):
+> **Apple Silicon (arm64) note:** several images deployed here are published for `amd64`
+> only (e.g. `api-extension`, the data-science-pipelines-operator). Under plain QEMU
+> emulation their Go binaries crash at startup (`lfstack.push invalid packing` /
+> `SIGSEGV` in `asm_amd64.s`). The fix is to enable **Rosetta 2** in the Podman machine,
+> which translates amd64 correctly:
 >
-> ```shell
-> podman machine ssh "sudo touch /etc/containers/enable-rosetta && sudo systemctl start rosetta-activation.service"
-> ```
+> - Rosetta is enabled via `[machine] rosetta = true` in
+>   `~/.config/containers/containers.conf` (there is no `podman machine` CLI flag for it).
+>   On recent Podman this is the default — check with `podman machine inspect --format '{{.Rosetta}}'`,
+>   so hand-editing the config is often unnecessary.
+> - Applying it to an **existing** machine only needs a **restart**, not a recreate:
+>   `podman machine stop && podman machine start` (the `podman machine rm` is not required —
+>   a restart re-provisions the Rosetta share and preserves your kind cluster).
+> - Verify inside the VM: `podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta"` should
+>   report `enabled`.
+>
+> With Rosetta on, the amd64 images run as-is. As an alternative you can build `api-extension`
+> natively for arm64:
+> `podman build --platform linux/arm64 -t quay.io/jdanek/api-extension:latest -f components/api-extension/Dockerfile components/api-extension/` then `kind load docker-image quay.io/jdanek/api-extension:latest`.
 >
 > See [macOS Podman + Rosetta setup](https://github.com/opendatahub-io/notebooks/blob/main/docs/macos-podman-rosetta.md).
 

--- a/components/01-argocd/httproute.yaml
+++ b/components/01-argocd/httproute.yaml
@@ -1,0 +1,24 @@
+---
+# Expose argocd-server through the Istio gateway so the argocd CLI can log in over a
+# stable connection, instead of core mode's ephemeral repo-server port-forward which is
+# fragile under load (mux: server closed).
+# https://github.com/jiridanek/rhoai-in-kind/issues/40
+#
+# argocd-server runs with --insecure (plain HTTP on :8080, exposed as svc port 80); the
+# gateway's https-terminate listener terminates TLS for *.apps.127.0.0.1.sslip.io and
+# forwards plain HTTP to it.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd-server-https
+  namespace: argocd
+spec:
+  parentRefs:
+    - name: gateway
+      namespace: istio-system
+      sectionName: https-terminate
+  hostnames: ["argocd.apps.127.0.0.1.sslip.io"]
+  rules:
+    - backendRefs:
+        - name: argocd-server
+          port: 80

--- a/components/01-argocd/kustomization.yaml
+++ b/components/01-argocd/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: argocd
 resources:
   - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.0.6/manifests/install.yaml
+  - httproute.yaml
 
 patches:
   - path: gittimeoutconfig.yaml

--- a/components/03-kf-pipelines.yaml
+++ b/components/03-kf-pipelines.yaml
@@ -28,7 +28,9 @@ spec:
   source:
     repoURL: https://github.com/opendatahub-io/data-science-pipelines-operator.git
     path: config/overlays/rhoai
-    targetRevision: HEAD
+    # can't use stable-2.x because there images aren't pinned, use :latest
+    #  https://github.com/opendatahub-io/data-science-pipelines-operator/blob/stable-2.x/config/base/params.env
+    targetRevision: v2.18.0
     kustomize:
       patches:
         - target:
@@ -46,6 +48,7 @@ spec:
             kind: Deployment
             name: data-science-pipelines-operator-controller-manager
           # value: quay.io/openshift/origin-oauth-proxy@sha256:1ece77d14a685ef2397c3a327844eea45ded00c95471e9e333e35ef3860b1895
+          # https://redhat-internal.slack.com/archives/C07K6N96FS4/p1759953469571239
           patch: |-
             apiVersion: apps/v1
             kind: Deployment
@@ -74,3 +77,6 @@ spec:
 #              value:
 #                name: IMAGES_APISERVER
 #                value: ...
+
+# I need to override https://github.com/opendatahub-io/data-science-pipelines-operator/blob/stable-2.x/config/base/params.env
+#  values because they use :latest, which is now 3.x stuff

--- a/components/04-odh-dashboard.yaml
+++ b/components/04-odh-dashboard.yaml
@@ -33,7 +33,10 @@ spec:
   source:
     repoURL: https://github.com/opendatahub-io/odh-dashboard.git
     path: manifests/rhoai/onprem
-    targetRevision: HEAD
+    # same problem as pipelines, stable-2.x references main
+    # and v2.37.1-odh seems the last without bring-your-own-id-connect
+    # https://github.com/opendatahub-io/odh-dashboard/releases/tag/v2.37.1-odh
+    targetRevision: v2.37.1-odh
     kustomize:
       patches:
         # https://github.com/opendatahub-io/odh-dashboard/pull/4099
@@ -49,6 +52,17 @@ spec:
         #      - rolebindings
         #      verbs:
         #      - create
+
+        # dashboard manifests use the deprecated var kustomize feature, so we patch the configmap where params.env is stored
+        #  approach would be the same with the current replacements feature
+        # https://github.com/opendatahub-io/odh-dashboard/blob/0da3abf2c5256bd5c0ed8e69d3c0da5a563f8caa/manifests/rhoai/onprem/kustomization.yaml#L9C1-L13C30
+        - target:
+              kind: ConfigMap
+              name: rhoai-dashboard-params
+          patch: |-
+            - op: replace
+              path: /data/odh-dashboard-image
+              value: quay.io/opendatahub/odh-dashboard:v2.37.1-odh
         - patch: |-
             - op: add
               path: /rules/-
@@ -84,7 +98,12 @@ spec:
 #            kind: Deployment
 #            name: rhods-dashboard
       images:
-        - registry.redhat.io/openshift4/ose-oauth-proxy=quay.io/jdanek/origin-oauth-proxy:latest
+        # - registry.redhat.io/openshift4/ose-oauth-proxy=quay.io/jdanek/origin-oauth-proxy:latest
+        # when there's digest, we must specify full digest, how annoying, see patch above
+        - registry.redhat.io/openshift4/ose-oauth-proxy-rhel9@sha256:ca21e218e26c46e3c63d926241846f8f307fd4a586cc4b04147da49af6018ef5=quay.io/jdanek/origin-oauth-proxy:latest
+        - registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4f8d66597feeb32bb18699326029f9a71a5aca4a57679d636b876377c2e95695=quay.io/jdanek/origin-oauth-proxy:latest
+#        - quay.io/opendatahub/odh-dashboard=quay.io/opendatahub/odh-dashboard:v2.38.2-odh
+        - quay.io/opendatahub/odh-dashboard=quay.io/opendatahub/odh-dashboard:v2.37.1-odh
       replicas:
         - name: rhods-dashboard
           count: 1

--- a/components/09-kf-notebooks/kustomization.yaml
+++ b/components/09-kf-notebooks/kustomization.yaml
@@ -20,8 +20,11 @@ resources:
   # the git urls will fail in github actions
   #- git@github.com:opendatahub-io/kubeflow.git/components/notebook-controller/config/overlays/openshift/
   #- git@github.com:opendatahub-io/kubeflow.git/components/odh-notebook-controller/config/base/
-  - https://github.com/opendatahub-io/kubeflow//components/notebook-controller/config/overlays/openshift/
-  - https://github.com/opendatahub-io/kubeflow//components/odh-notebook-controller/config/base/
+
+  # https://github.com/opendatahub-io/kubeflow/releases/tag/v1.10.0-6
+  # https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3339632379
+  - https://github.com/opendatahub-io/kubeflow//components/notebook-controller/config/overlays/openshift?ref=v1.10.0-6&submodules=false
+  - https://github.com/opendatahub-io/kubeflow//components/odh-notebook-controller/config/base?ref=v1.10.0-6&submodules=false
   - culler-config.yaml
 
 patches:

--- a/components/api-extension/Dockerfile
+++ b/components/api-extension/Dockerfile
@@ -16,11 +16,13 @@
 # podman push quay.io/jdanek/api-extension:latest
 # kind load docker-image quay.io/jdanek/api-extension:latest
 
-FROM docker.io/library/golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 as builder
+ARG TARGETOS
+ARG TARGETARCH
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /api-extension
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build -o /api-extension
 
 FROM fedora
 COPY --from=builder /api-extension /

--- a/components/crds/kustomization.yaml
+++ b/components/crds/kustomization.yaml
@@ -6,6 +6,7 @@ kind: Kustomization
 
 resources:
   - route.yaml
+  - oauthclient.yaml
   - servicemonitor.yaml
   - consolelink.yaml
   - dsc.yaml

--- a/components/crds/oauthclient.yaml
+++ b/components/crds/oauthclient.yaml
@@ -1,0 +1,33 @@
+---
+# odh-notebook-controller creates an OAuthClient (oauth.openshift.io/v1) per notebook
+# when `notebooks.opendatahub.io/inject-oauth: true`. On vanilla Kubernetes that API
+# does not exist, so the reconcile fails ("no matches for kind OAuthClient") and the
+# controller locks the notebook (kubeflow-resource-stopped), leaving the StatefulSet at
+# 0 replicas so the workbench pod never spawns. A fake CRD is enough: the object only
+# needs to accept CRUD, it need not be functional. Cluster-scoped, like the real one
+# (which is why odh-notebook-controller uses a finalizer rather than owner refs to GC it).
+#
+# This is recent upstream behaviour: OAuthClient usage was added in
+# opendatahub-io/kubeflow#449, and the finalizer lifecycle in #605 (daniellutz) / #693.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    crd/fake: "true"
+  name: oauthclients.oauth.openshift.io
+spec:
+  group: oauth.openshift.io
+  names:
+    kind: OAuthClient
+    listKind: OAuthClientList
+    singular: oauthclient
+    plural: oauthclients
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: true

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -232,12 +232,24 @@ def main():
 
     with gha_log_group("Login to ArgoCD"):
         sh("kubectl config set-context --current --namespace=argocd")
-        sh("argocd login --core")
         # ArgoCD pods may still be starting (slow image pulls); wait until they are Available so
-        # `argocd cluster add` does not race a not-yet-ready repo-server.
+        # login / cluster-add do not race a not-yet-ready server.
         sh("kubectl wait --for=condition=Available deployment --all -n argocd --timeout=180s")
-        # time="2025-04-10T21:52:51Z" level=error msg="finished unary call with code Unknown" error="error setting cluster info in cache: dial tcp [::1]:42171: connect: connection refused" grpc.code=Unknown grpc.method=Create grpc.service=cluster.ClusterService grpc.start_time="2025-04-10T21:52:51Z" grpc.time_ms=272.867 span.kind=server system=grpc
-        sh(f"timeout {ARGOCD_TIMEOUT} bash -c 'while ! argocd cluster add kind-kind --yes; do sleep 1; done'")
+        # Log in to argocd-server through the Istio gateway (components/01-argocd/httproute.yaml)
+        # rather than core mode: core mode's ephemeral repo-server port-forward is fragile under
+        # load (mux: server closed). https://github.com/jiridanek/rhoai-in-kind/issues/40
+        # `set +x` in the inner shell keeps the admin password out of the `set -x` trace.
+        sh(
+            f"""timeout {ARGOCD_TIMEOUT} bash -c '
+                set +x
+                pw=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{{.data.password}}" | base64 --decode)
+                while ! argocd login argocd.apps.127.0.0.1.sslip.io --username admin --password "$pw" --grpc-web --insecure; do sleep 2; done
+            '"""
+        )
+        # No `argocd cluster add` needed: every Application targets the in-cluster endpoint
+        # (https://kubernetes.default.svc). Registering the external kind-kind context would also
+        # fail in server mode, because argocd-server (in-pod) cannot reach its host-only
+        # 127.0.0.1:6443 to validate the cluster.
 
     # actually needed, did something that DSP Workbenches dashboard tab won't load without
     with gha_log_group("Install KF Pipelines"):

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -3,17 +3,28 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
-import contextlib
 import pathlib
 import sys
-import subprocess
 import textwrap
-import time
-from typing import Callable, Any
 
 import certs
+
+# rhoai_in_kind lives in ../src; put it on the path so this script runs under a
+# plain interpreter (CI: `python components/deploy.py`) as well as under an
+# editable install (local uv venv).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
+
+from rhoai_in_kind import (
+    TestFrame,
+    create_resource,
+    gha_log_group,
+    sh,
+    wait_for_webhook_service_endpoint,
+)
+
+REDHAT_ODS_APPLICATIONS = "redhat-ods-applications"
+RHODS_NOTEBOOKS = "rhods-notebooks"
 
 
 def main():
@@ -111,14 +122,14 @@ def main():
     # with gha_log_group("Check that API extension server works"):
     #     tf.defer(None, lambda _: sh("timeout 30s bash -c 'while ! oc new-project dsp-wb-test; do sleep 1; done'"))
 
-    with gha_log_group("Run kubectl create namespaces redhat-ods-applications"):
-        sh("kubectl get namespace redhat-ods-applications || kubectl create namespace redhat-ods-applications")
+    with gha_log_group(f"Run kubectl create namespaces {REDHAT_ODS_APPLICATIONS}"):
+        sh(f"kubectl get namespace {REDHAT_ODS_APPLICATIONS} || kubectl create namespace {REDHAT_ODS_APPLICATIONS}")
 
-    with gha_log_group("Setup rhods-notebooks namespace"):
+    with gha_log_group(f"Setup {RHODS_NOTEBOOKS} namespace"):
         # c.f. dashboard's validateNotebookNamespaceRoleBinding
         # it will create rolebinding ${notebookNamespace}-image-pullers in dashboardNamespace
         # and it needs a clusterrole system:image-puller to exist, which does not exsist on kind by default
-        sh("kubectl get namespace rhods-notebooks || kubectl create namespace rhods-notebooks")
+        sh(f"kubectl get namespace {RHODS_NOTEBOOKS} || kubectl create namespace {RHODS_NOTEBOOKS}")
         # dummy verb and resource, just to have something there
         sh("kubectl create clusterrole system:image-puller --verb=list --resource=imagestreams.image.openshift.io --dry-run=client -o yaml | kubectl apply -f -")
         # I have no idea why the next line was needed; it is not mentioned in dashboard sources except in manifests
@@ -127,12 +138,12 @@ def main():
         # this is to mitigate fallout from https://github.com/opendatahub-io/odh-dashboard/pull/4049
         # not sure if this is permanent or just a temporary workaround, NOTE: rhods-notebooks serviceaccount!
         # language=Yaml
-        dashboardPullerRole = textwrap.dedent("""
+        dashboardPullerRole = textwrap.dedent(f"""
         apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         metadata:
-            name: rhods-notebooks-image-pullers
-            namespace: redhat-ods-applications
+            name: {RHODS_NOTEBOOKS}-image-pullers
+            namespace: {REDHAT_ODS_APPLICATIONS}
         roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: ClusterRole
@@ -140,7 +151,7 @@ def main():
         subjects:
             - apiGroup: rbac.authorization.k8s.io
               kind: Group
-              name: system:serviceaccounts:rhods-notebooks
+              name: system:serviceaccounts:{RHODS_NOTEBOOKS}
         """)
         create_resource(dashboardPullerRole)
 
@@ -193,11 +204,11 @@ def main():
                 import boto3
 
             # MINIO_ROOT_USER=sh("oc get -n minio secret minio-root-user -o template --template '{{.data.MINIO_ROOT_USER}}'", stdout=subprocess.PIPE).stdout.strip()
-            MINIO_ROOT_USER="AWS_ACCESS_KEY_ID"
+            MINIO_ROOT_USER = "AWS_ACCESS_KEY_ID"
             # MINIO_ROOT_PASSWORD=sh("oc get -n minio secret minio-root-user -o template --template '{{.data.MINIO_ROOT_PASSWORD}}'", stdout=subprocess.PIPE).stdout.strip()
-            MINIO_ROOT_PASSWORD="AWS_SECRET_ACCESS_KEY"
+            MINIO_ROOT_PASSWORD = "AWS_SECRET_ACCESS_KEY"
             # MINIO_HOST="https://" + sh("oc get -n minio route minio-s3 -o template --template '{{.spec.host}}'", stdout=subprocess.PIPE).stdout.strip()
-            MINIO_HOST="https://minio.apps.127.0.0.1.sslip.io"
+            MINIO_HOST = "https://minio.apps.127.0.0.1.sslip.io"
 
             s3 = boto3.client("s3",
                               endpoint_url=MINIO_HOST,
@@ -224,22 +235,22 @@ def main():
     # actually needed, did something that DSP Workbenches dashboard tab won't load without
     with gha_log_group("Install KF Pipelines"):
         # dspa is looking up configmaps in this namespace
-        #sh("kubectl create namespace openshift-config-managed --dry-run=client -o yaml | kubectl apply -f -")
+        # sh("kubectl create namespace openshift-config-managed --dry-run=client -o yaml | kubectl apply -f -")
 
         sh("timeout 30s bash -c 'while ! argocd app sync kf-pipelines; do sleep 1; done'")
 
         # wait for argocd to sync the application
         # wait for deployment as it is more robust
         tf.defer(None, lambda _: sh(
-            "oc wait --for=condition=Available deployment -l app.kubernetes.io/name=data-science-pipelines-operator -n redhat-ods-applications --timeout=120s"))
+            f"oc wait --for=condition=Available deployment -l app.kubernetes.io/name=data-science-pipelines-operator -n {REDHAT_ODS_APPLICATIONS} --timeout=120s"))
 
     with gha_log_group("Install KF Notebooks"):
         sh("kubectl apply -k components/09-kf-notebooks")
         tf.defer(None, lambda _: sh(
-            "oc wait --for=condition=Available deployment -l app=notebook-controller -n redhat-ods-applications --timeout=120s"))
+            f"oc wait --for=condition=Available deployment -l app=notebook-controller -n {REDHAT_ODS_APPLICATIONS} --timeout=120s"))
         tf.defer(None, lambda _: sh(
-            "oc wait --for=condition=Available deployment -l app=odh-notebook-controller -n redhat-ods-applications --timeout=120s"))
-        tf.defer(None, lambda _: wait_for_webhook_service_endpoint())
+            f"oc wait --for=condition=Available deployment -l app=odh-notebook-controller -n {REDHAT_ODS_APPLICATIONS} --timeout=120s"))
+        tf.defer(None, lambda _: wait_for_webhook_service_endpoint(namespace=REDHAT_ODS_APPLICATIONS))
 
     with gha_log_group("Install Workbenches"):
         # error unmarshaling JSON: while decoding JSON: json: unknown field "apiGroup"
@@ -258,9 +269,9 @@ def main():
         #     sh(f"{kustomize_bin} build components/08-workbenches | kubectl apply -f -")
 
         # we don't have permissions to pull from quay.io/rhoai
-        #workbench_repo = "https://github.com/red-hat-data-services/notebooks"
+        # workbench_repo = "https://github.com/red-hat-data-services/notebooks"
         workbench_repo = "https://github.com/opendatahub-io/notebooks"
-        sh(f"kubectl apply -k '{workbench_repo}//manifests/base/?timeout=90s&ref={workbench_branch}&depth=1&submodules=false' --namespace redhat-ods-applications",
+        sh(f"kubectl apply -k '{workbench_repo}//manifests/base/?timeout=90s&ref={workbench_branch}&depth=1&submodules=false' --namespace {REDHAT_ODS_APPLICATIONS}",
            env={"GIT_LFS_SKIP_SMUDGE": "1"})
 
     with gha_log_group("Install Service CA Operator"):
@@ -286,7 +297,7 @@ def main():
         # was getting a CRD missing error, somehow argo was not waiting to establish OdhDocument?
         sh("timeout 30s bash -c 'while ! argocd app sync odh-dashboard; do sleep 1; done'")
         tf.defer(None, lambda _: sh(
-            "kubectl wait --for=condition=Available deployment -l app=rhods-dashboard -n redhat-ods-applications --timeout=120s"))
+            f"kubectl wait --for=condition=Available deployment -l app=rhods-dashboard -n {REDHAT_ODS_APPLICATIONS} --timeout=120s"))
         # wait for webpage availability
         tf.defer(None, lambda _: sh('''timeout 60s bash -c 'while ! curl -k "https://rhods-dashboard.127.0.0.1.sslip.io/"; do sleep 2; done' '''))
 
@@ -296,7 +307,7 @@ def main():
         sh("kubectl apply -f components/07-dsc-dsci.yaml --server-side --subresource=status || true")
 
     with gha_log_group("Install local-path provisioner"):
-        sh("kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.31/deploy/local-path-storage.yaml")
+        sh("kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.33/deploy/local-path-storage.yaml")
         tf.defer(None, lambda _: sh(
             "kubectl wait deployments --all --namespace=local-path-storage --for=condition=Available --timeout=100s"))
         # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
@@ -310,101 +321,6 @@ def main():
     with gha_log_group("Run deferred functions"):
         with tf:
             pass
-
-
-def sh(cmd: str, env: dict[str, str] | None = None, input: str | None = None, **kwargs) -> subprocess.CompletedProcess[str]:
-    """Runs a shell command."""
-    env = env or {}
-    print(f"$ {cmd}", file=sys.stdout)
-    sys.stdout.flush()
-    completed_process = subprocess.run(
-        f"set -Eeuxo pipefail; {cmd}",
-        shell=True,
-        executable="/bin/bash",
-        env={**os.environ, **env},
-        input=input,
-        check=True,
-        text=True,
-        **kwargs,
-    )
-    sys.stdout.flush()
-    return completed_process
-
-def create_resource(resource: str):
-    sh("kubectl apply -f -", input=resource)
-
-def wait_for_webhook_service_endpoint():
-    service_name = "odh-notebook-controller-webhook-service"
-    namespace = "redhat-ods-applications"
-    timeout_seconds = 60
-    poll_interval_seconds = 1
-    start_time = time.time()
-
-    print(f"Waiting for endpoints of service '{service_name}' in namespace '{namespace}' to be ready...")
-
-    while time.time() - start_time < timeout_seconds:
-        try:
-            # Use oc get endpoints -o json to check for ready addresses
-            command = [
-                "kubectl", "get", "endpoints", service_name,
-                "-n", namespace,
-                "-o", "json"
-            ]
-            result = sh(" ".join(command), capture_output=True, timeout=5)
-            endpoints_data = json.loads(result.stdout)
-
-            # Check if 'subsets' exist and contain addresses
-            if "subsets" in endpoints_data:
-                for subset in endpoints_data["subsets"]:
-                    # Check for ready addresses ('addresses') vs not ready ('notReadyAddresses')
-                    if "addresses" in subset and subset["addresses"]:
-                        print(f"Endpoints for service '{service_name}' are ready.")
-                        return
-
-            print(f"Endpoints for '{service_name}' not ready yet, checking again in {poll_interval_seconds}s...")
-
-        except subprocess.CalledProcessError as e:
-            # Handle case where endpoints object might not exist yet or other oc errors
-            print(f"Error checking endpoints (will retry): {e.stderr}")
-        except subprocess.TimeoutExpired:
-            print("Timeout during 'oc get endpoints' command (will retry).")
-        except json.JSONDecodeError as e:
-            print(f"Error decoding JSON output from oc get endpoints (will retry): {e}")
-        except Exception as e:
-            print(f"An unexpected error occurred (will retry): {e}")
-
-        time.sleep(poll_interval_seconds)
-
-    raise TimeoutError(f"Timeout waiting for endpoints of service '{service_name}' in namespace '{namespace}' after {timeout_seconds} seconds.")
-
-
-# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
-@contextlib.contextmanager
-def gha_log_group(title: str) -> None:
-    """Prints the starting and ending magic strings for GitHub Actions line group in log."""
-    print(f"::group::{title}", file=sys.stdout)
-    sys.stdout.flush()
-    try:
-        yield
-    finally:
-        print("::endgroup::", file=sys.stdout)
-        sys.stdout.flush()
-
-
-class TestFrame:
-    def __init__(self):
-        self.stack = []
-
-    def defer[T](self, obj: T, fn: Callable[[T], Any]):
-        self.stack.append((obj, fn))
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        while self.stack:
-            obj, fn = self.stack.pop(0)
-            fn(obj)
 
 
 if __name__ == "__main__":

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -256,8 +256,12 @@ def main():
         #
         #     sh(f'"{kustomize_bin}" version')
         #     sh(f"{kustomize_bin} build components/08-workbenches | kubectl apply -f -")
-        sh(f"kubectl apply -k 'https://github.com/red-hat-data-services/notebooks//manifests/base/?timeout=90s&ref={workbench_branch}' --namespace redhat-ods-applications")
 
+        # we don't have permissions to pull from quay.io/rhoai
+        #workbench_repo = "https://github.com/red-hat-data-services/notebooks"
+        workbench_repo = "https://github.com/opendatahub-io/notebooks"
+        sh(f"kubectl apply -k '{workbench_repo}//manifests/base/?timeout=90s&ref={workbench_branch}&depth=1&submodules=false' --namespace redhat-ods-applications",
+           env={"GIT_LFS_SKIP_SMUDGE": "1"})
 
     with gha_log_group("Install Service CA Operator"):
         sh("kubectl label node --all node-role.kubernetes.io/master=")

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import contextlib
+import pathlib
 import sys
 import subprocess
 import textwrap
@@ -71,12 +72,13 @@ def main():
         # TLSRoute is considered "experimental"
         # https://github.com/kubernetes-sigs/gateway-api/issues/2643
         sh('kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-          { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.3.0" | kubectl apply -f -; }')
+          { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.3.0&depth=1" | kubectl apply -f -; }')
 
-        sh("curl -L https://istio.io/downloadIstio | sh -", env={
-            "ISTIO_VERSION": ISTIO_VERSION,
-            "TARGET_ARCH": TARGET_ARCH,
-        })
+        if not pathlib.Path(f"istio-{ISTIO_VERSION}/bin/istioctl").exists():
+            sh("curl -L https://istio.io/downloadIstio | sh -", env={
+                "ISTIO_VERSION": ISTIO_VERSION,
+                "TARGET_ARCH": TARGET_ARCH,
+            })
         sh(f"istio-{ISTIO_VERSION}/bin/istioctl install --set values.pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=true --set profile=minimal -y")
 
         sh("kubectl apply -f components/06-gateway.yaml")

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -26,6 +26,10 @@ from rhoai_in_kind import (
 REDHAT_ODS_APPLICATIONS = "redhat-ods-applications"
 RHODS_NOTEBOOKS = "rhods-notebooks"
 
+# Ceiling for the ArgoCD retry loops (`timeout <N> bash -c 'while ! argocd ...'`).
+# It is a retry budget, not a fixed wait: the loop exits as soon as the command succeeds.
+ARGOCD_TIMEOUT = "60s"
+
 
 def main():
     tf = TestFrame()
@@ -229,15 +233,18 @@ def main():
     with gha_log_group("Login to ArgoCD"):
         sh("kubectl config set-context --current --namespace=argocd")
         sh("argocd login --core")
+        # ArgoCD pods may still be starting (slow image pulls); wait until they are Available so
+        # `argocd cluster add` does not race a not-yet-ready repo-server.
+        sh("kubectl wait --for=condition=Available deployment --all -n argocd --timeout=180s")
         # time="2025-04-10T21:52:51Z" level=error msg="finished unary call with code Unknown" error="error setting cluster info in cache: dial tcp [::1]:42171: connect: connection refused" grpc.code=Unknown grpc.method=Create grpc.service=cluster.ClusterService grpc.start_time="2025-04-10T21:52:51Z" grpc.time_ms=272.867 span.kind=server system=grpc
-        sh("timeout 30s bash -c 'while ! argocd cluster add kind-kind --yes; do sleep 1; done'")
+        sh(f"timeout {ARGOCD_TIMEOUT} bash -c 'while ! argocd cluster add kind-kind --yes; do sleep 1; done'")
 
     # actually needed, did something that DSP Workbenches dashboard tab won't load without
     with gha_log_group("Install KF Pipelines"):
         # dspa is looking up configmaps in this namespace
         # sh("kubectl create namespace openshift-config-managed --dry-run=client -o yaml | kubectl apply -f -")
 
-        sh("timeout 30s bash -c 'while ! argocd app sync kf-pipelines; do sleep 1; done'")
+        sh(f"timeout {ARGOCD_TIMEOUT} bash -c 'while ! argocd app sync kf-pipelines; do sleep 1; done'")
 
         # wait for argocd to sync the application
         # wait for deployment as it is more robust
@@ -295,7 +302,7 @@ def main():
 
     with gha_log_group("Install ODH Dashboard"):
         # was getting a CRD missing error, somehow argo was not waiting to establish OdhDocument?
-        sh("timeout 30s bash -c 'while ! argocd app sync odh-dashboard; do sleep 1; done'")
+        sh(f"timeout {ARGOCD_TIMEOUT} bash -c 'while ! argocd app sync odh-dashboard; do sleep 1; done'")
         tf.defer(None, lambda _: sh(
             f"kubectl wait --for=condition=Available deployment -l app=rhods-dashboard -n {REDHAT_ODS_APPLICATIONS} --timeout=120s"))
         # wait for webpage availability

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -293,6 +293,44 @@ def main():
         sh(f"kubectl apply -k '{workbench_repo}//manifests/base/?timeout=90s&ref={workbench_branch}&depth=1&submodules=false' --namespace {REDHAT_ODS_APPLICATIONS}",
            env={"GIT_LFS_SKIP_SMUDGE": "1"})
 
+    with gha_log_group("Alias minimal workbench imagestream to the downstream name"):
+        # opendatahub-tests' workbench tests request the downstream image name
+        # `s2i-minimal-notebook` (opendatahub-tests tests/workbenches/conftest.py:44; the
+        # distribution is derived from our DSC release.name "OpenShift AI Self-Managed" =>
+        # downstream). We deploy the upstream `jupyter-minimal-notebook` imagestream, so create a
+        # downstream-named alias of it. The odh-notebook-controller mutating webhook
+        # (SetContainerImageFromRegistry) resolves the workbench image from this imagestream's
+        # status.tags[].dockerImageReference. This is the only imagestream the tests reference.
+        # https://github.com/jiridanek/rhoai-in-kind/issues/48
+        import json
+
+        # status.tags[].items[].dockerImageReference is filled in by the best-effort
+        # mutate-imagestream-add-simplified-status Kyverno policy, so don't assume it is present
+        # the instant the workbench manifests apply — wait until the source has a resolved
+        # reference, otherwise the alias could be created without a resolvable workbench image.
+        sh(
+            f"""timeout 120s bash -c 'while [ -z "$(kubectl -n {REDHAT_ODS_APPLICATIONS} get imagestream jupyter-minimal-notebook -o jsonpath="{{.status.tags[*].items[*].dockerImageReference}}" 2>/dev/null)" ]; do sleep 2; done'"""
+        )
+        src = json.loads(sh(
+            f"kubectl -n {REDHAT_ODS_APPLICATIONS} get imagestream jupyter-minimal-notebook -o json",
+            capture_output=True).stdout)
+        labels = {
+            k: v for k, v in (src["metadata"].get("labels") or {}).items()
+            # don't advertise the alias as a dashboard workbench image, or it shows up as a
+            # duplicate entry in the spawner next to jupyter-minimal-notebook
+            if k != "opendatahub.io/notebook-image"
+        }
+        src["metadata"] = {
+            "name": "s2i-minimal-notebook",
+            "namespace": REDHAT_ODS_APPLICATIONS,
+            "labels": labels,
+            # not operator-managed: this alias is maintained here, not by the ODH operator
+            "annotations": {"opendatahub.io/managed": "false"},
+        }
+        # carry over the (now-resolved) status.tags so the alias resolves regardless of whether
+        # the Kyverno mutation fires again on this create.
+        sh("kubectl apply -f -", input=json.dumps(src))
+
     with gha_log_group("Install Service CA Operator"):
         sh("kubectl label node --all node-role.kubernetes.io/master=")
         sh("timeout 30s bash -c 'while ! kubectl apply -k components/05-ca-operator; do sleep 1; done'")

--- a/components/ods-ci/test-variables.yml
+++ b/components/ods-ci/test-variables.yml
@@ -86,6 +86,9 @@ MONITORING_NAMESPACE: redhat-ods-monitoring
 OPERATOR_NAME: rhods-operator
 OPERATOR_NAMESPACE: redhat-ods-operator
 NOTEBOOKS_NAMESPACE: rhods-notebooks
+# Required by ods-ci release-2.25 Suite Setup (RHOSi.resource: IF "${INSTALL_TYPE}" == "OperatorHub").
+# Any non-OperatorHub value works and skips the OperatorHub-only setup branch.
+INSTALL_TYPE: CLI
 OPENSHIFT_PIPELINES_CHANNEL: latest
 TEST_CLUSTER_NAME: dashboard-e2e
 #TEST_CLUSTER_URL: https://console-openshift-console.apps.some-cluster.some-platform.rh-ods.com

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@ name = "rhoai-in-kind"
 version = "0.1.0"
 description = "Runs OpenShift AI Workbenches in GitHub Actions"
 requires-python = ">=3.13, <3.14"
-dependencies = []
+dependencies = [
+    "boto3",  # used by deploy.py create_buckets() to provision MinIO/S3 buckets
+]
 
 [tool.ruff]
 line-length = 120
@@ -15,3 +17,8 @@ select = [
 ]
 # https://docs.astral.sh/ruff/rules/multi-line-implicit-string-concatenation/#formatter-compatibility
 flake8-implicit-str-concat.allow-multiline = false
+
+# https://docs.astral.sh/uv/concepts/build-backend/#choosing-a-build-backend
+[build-system]
+requires = ["uv_build>=0.11.8,<0.13"]
+build-backend = "uv_build"

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING, Generator
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
+
+
+def sh(
+    cmd: str, env: dict[str, str] | None = None,
+    input: str | None = None,
+    **kwargs
+) -> subprocess.CompletedProcess[str]:
+    """Runs a shell command."""
+    env = env or {}
+    print(f"$ {cmd}", file=sys.stdout)
+    sys.stdout.flush()
+    completed_process = subprocess.run(
+        f"set -Eeuxo pipefail; {cmd}",
+        shell=True,
+        executable="/bin/bash",
+        env={**os.environ, **env},
+        input=input,
+        check=True,
+        text=True,
+        **kwargs,
+    )
+    sys.stdout.flush()
+    return completed_process
+
+
+def create_resource(resource: str):
+    sh("kubectl apply -f -", input=resource)
+
+
+def wait_for_webhook_service_endpoint(namespace: str):
+    service_name = "odh-notebook-controller-webhook-service"
+    timeout_seconds = 60
+    poll_interval_seconds = 1
+    start_time = time.time()
+
+    print(f"Waiting for endpoints of service '{service_name}' in namespace '{namespace}' to be ready...")
+
+    while time.time() - start_time < timeout_seconds:
+        try:
+            # Use oc get endpoints -o json to check for ready addresses
+            command = [
+                "kubectl", "get", "endpoints", service_name,
+                "-n", namespace,
+                "-o", "json"
+            ]
+            result = sh(" ".join(command), capture_output=True, timeout=5)
+            endpoints_data = json.loads(result.stdout)
+
+            # Check if 'subsets' exist and contain addresses
+            if "subsets" in endpoints_data:
+                for subset in endpoints_data["subsets"]:
+                    # Check for ready addresses ('addresses') vs not ready ('notReadyAddresses')
+                    if "addresses" in subset and subset["addresses"]:
+                        print(f"Endpoints for service '{service_name}' are ready.")
+                        return
+
+            print(f"Endpoints for '{service_name}' not ready yet, checking again in {poll_interval_seconds}s...")
+
+        except subprocess.CalledProcessError as e:
+            # Handle case where endpoints object might not exist yet or other oc errors
+            print(f"Error checking endpoints (will retry): {e.stderr}")
+        except subprocess.TimeoutExpired:
+            print("Timeout during 'oc get endpoints' command (will retry).")
+        except json.JSONDecodeError as e:
+            print(f"Error decoding JSON output from oc get endpoints (will retry): {e}")
+        except Exception as e:
+            print(f"An unexpected error occurred (will retry): {e}")
+
+        time.sleep(poll_interval_seconds)
+
+    raise TimeoutError(
+        f"Timeout waiting for endpoints of service '{service_name}' in namespace '{namespace}' after {timeout_seconds} seconds.")
+
+
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines
+@contextlib.contextmanager
+def gha_log_group(title: str) -> Generator[None, Any, None]:
+    """Prints the starting and ending magic strings for GitHub Actions line group in log."""
+    print(f"::group::{title}", file=sys.stdout)
+    sys.stdout.flush()
+    try:
+        yield
+    finally:
+        print("::endgroup::", file=sys.stdout)
+        sys.stdout.flush()
+
+
+class TestFrame:
+    def __init__(self):
+        self.stack = []
+
+    def defer[T](self, obj: T, fn: Callable[[T], Any]):
+        self.stack.append((obj, fn))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        while self.stack:
+            obj, fn = self.stack.pop(0)
+            fn(obj)


### PR DESCRIPTION
## Summary

Makes **rhoai-2.25** a working, pinned baseline for local/CI deployment (kind + `deploy.py`), and fixes the CI workflows (`ods-ci`, `cypress`, `opendatahub-tests`/shiftleft) that had drifted against their upstream `main`/`master` branches so the pinned baseline actually passes.

## Why

CI on `main` was chronically red because several checked-out test suites track a floating upstream ref (`master`/`main`) that had moved ahead of what our pinned stack (workbench `v1.36.0`, dashboard `v2.37.1-odh`) supports — e.g. ods-ci `master` requires a "Hardware profile" spawner UI our dashboard doesn't render, and odh-dashboard `main`'s npm-workspaces layout broke the cypress install. This PR pins every moving piece to the rhoai-2.25 line so there is a stable, reproducible baseline to build on, then fixes the specific breakages that pinning exposed.

## What changed

### Pin the stack to rhoai-2.25
- `components/deploy.py`, GitHub workflows: bump `workbench_branch` to `v1.36.0` (≡ rhoai-2.25) and switch the notebooks source to `opendatahub-io/notebooks`.
- Pin `notebook-controller` / `odh-notebook-controller` to `v1.10.0-6`.
- Pin `odh-dashboard` deployment and DSPA to specific versions (`components/04-odh-dashboard.yaml`).
- Pin `opendatahub-tests` checkout to a known-working commit (`94670b33`).

### CI: pin test suites to match the baseline (was drifting against master/main)
- **ods-ci**: checkout `red-hat-data-services/ods-ci@release-2.25` instead of `master`; add `INSTALL_TYPE: CLI` to `components/ods-ci/test-variables.yml` (needed by release-2.25, not by the older master we used to run). Issue: #42.
- **cypress**: checkout `opendatahub-io/odh-dashboard@v2.37.1-odh` (matches the deployed dashboard image) instead of `main`; run `npm ci` from the repo root (`odh-dashboard` is an npm-workspaces monorepo — `npm --prefix frontend ci` no longer works there). Issue: #47.
- **opendatahub-tests / shiftleft**: deselect `test_oauth_container_resource_customization` — it asserts an oauth-sidecar CPU request that our `remove-cpu-memory-requests` Kyverno policy deliberately strips; not fixable without dropping that policy. Issue: #48.
- Restrict `push` triggers to `branches: [main]` on all three workflows, so a same-repo PR branch push no longer double-triggers CI via both `push` and `pull_request`. Issue: #46.

### Cluster bring-up fixes needed to make the pinned stack deploy at all
- Add a fake `OAuthClient` CRD (`components/crds/oauthclient.yaml`) — the pinned notebook-controller expects the OpenShift OAuth API, which kind doesn't have.
- Alias the `jupyter-minimal-notebook` ImageStream as `s2i-minimal-notebook` in `deploy.py` — opendatahub-tests' workbench tests request the downstream image name, which our upstream deployment doesn't produce; the odh-notebook-controller mutating webhook resolves the workbench image from this alias's `status.tags`. Waits (bounded, 120s) for the source's `status.tags[].dockerImageReference` to resolve (Kyverno-mutated) before copying, so the alias isn't created with an unresolvable reference. Issue: #48.
- ArgoCD: log in via the Istio gateway instead of core mode; wait for ArgoCD readiness and factor out the sync timeout.
- `api-extension`: build the container image for the host's target architecture instead of hardcoding `amd64` (needed on Apple Silicon).

### Refactor
- Extract shell helpers (`sh`, `gha_log_group`, etc.) out of `deploy.py` into a proper `src/rhoai_in_kind` package.

### Docs
- Document the rootful + Rosetta podman machine setup required on Apple Silicon (amd64 ODH images otherwise crash under emulation).
- Document macOS DNS troubleshooting for `*.sslip.io` resolution (local dnsmasq).
- Note the Apple Silicon consideration for the `api-extension` amd64 image.

## Known limitations (tracked separately, not fixed here)

- `s2i-minimal-notebook` alias vs. cypress `testWorkbenchImages.cy.ts`: the alias intentionally has the `opendatahub.io/notebook-image` label stripped (so it doesn't show as a duplicate entry in the dashboard spawner next to `jupyter-minimal-notebook`), but odh-dashboard's own cypress test discovers candidate images by ImageStream name substring (`*notebook*`) regardless of that label, so it now expects the alias to be spawner-selectable and fails. To be resolved in a follow-up.
- ods-ci `release-2.25` pin is to a branch, not a fixed commit, left intentionally floating for now (issue #42 stays open).

## Testing

- Full local `kind` deploy against this branch, verified through workbench creation via the dashboard.
- `opendatahub-tests/tests/workbenches` run locally end-to-end against the alias fix (`test_create_simple_notebook` passes; `test_oauth_container_resource_customization` deselected).
- cypress workbench specs run locally against the pinned `v2.37.1-odh` checkout.
