### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -7,15 +7,13 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
-permissions:
-  contents: read
-  actions: read
-  packages: read
-  id-token: none
+permissions: {}
 
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+  id-token: none
+
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -7,12 +7,13 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
+permissions:
+  contents: read
+
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -7,13 +7,13 @@ on:
   schedule:
     - cron: '0 2 * * *' # at 02:00
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   rhoai-in-kind:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/jiridanek/rhoai-in-kind/security/code-scanning/8](https://github.com/jiridanek/rhoai-in-kind/security/code-scanning/8)

Add an explicit `permissions` block to the workflow root, immediately after triggers (`on:`...) and before `jobs:`.  
Best minimal fix without changing existing behavior is:

- `permissions:`
  - `contents: read`

This satisfies CodeQL’s recommendation and keeps token access limited to read-only repository contents for all jobs unless overridden later. No imports, methods, or dependencies are needed since this is YAML configuration only.

File to change:
- `.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml`
- Insert the block between lines 8 and 10 (after `schedule` and before `jobs`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows with explicit, read-only repository access.
  * Disabled unnecessary token permissions for improved workflow security.
  * Improved consistency across testing and continuous integration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->