### PR TITLE
deploy: pin data-science-pipelines-operator and notebook-controller to their rhoai-2.25 versions

### DIFF
--- a/components/03-kf-pipelines.yaml
+++ b/components/03-kf-pipelines.yaml
@@ -30,7 +30,9 @@ spec:
     path: config/overlays/rhoai
     # can't use stable-2.x because there images aren't pinned, use :latest
     #  https://github.com/opendatahub-io/data-science-pipelines-operator/blob/stable-2.x/config/base/params.env
-    targetRevision: v2.18.0
+    # v2.15.1 is what rhoai-2.25 actually ships, per
+    #  https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3351838012
+    targetRevision: v2.15.1
     kustomize:
       patches:
         - target:

--- a/components/09-kf-notebooks/kustomization.yaml
+++ b/components/09-kf-notebooks/kustomization.yaml
@@ -21,10 +21,18 @@ resources:
   #- git@github.com:opendatahub-io/kubeflow.git/components/notebook-controller/config/overlays/openshift/
   #- git@github.com:opendatahub-io/kubeflow.git/components/odh-notebook-controller/config/base/
 
+  # v1.10.0-6 (the community tag matching opendatahub-community#183's "ODH 2.35.0 ~ rhoai-2.25"
+  # tracker) already contains RHOAIENG-32633 (renamed the Elyra runtime config's display_name
+  # from "Data Science Pipeline" to "AI Pipeline"), which Jira targets at rhoai-3.0, not 2.25 -
+  # it landed on main days before the community tag was cut, but isn't in the downstream 2.x
+  # scope. Verified directly against the real downstream red-hat-data-services/kubeflow
+  # `rhoai-2.25` branch: both controllers are pinned there to v1.10.0-5, and that build still
+  # says "Data Science Pipeline" (matching ods-ci's release-2.25 suite).
   # https://github.com/opendatahub-io/kubeflow/releases/tag/v1.10.0-6
   # https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3339632379
-  - https://github.com/opendatahub-io/kubeflow//components/notebook-controller/config/overlays/openshift?ref=v1.10.0-6&submodules=false
-  - https://github.com/opendatahub-io/kubeflow//components/odh-notebook-controller/config/base?ref=v1.10.0-6&submodules=false
+  # https://issues.redhat.com/browse/RHOAIENG-32633
+  - https://github.com/opendatahub-io/kubeflow//components/notebook-controller/config/overlays/openshift?ref=v1.10.0-5&submodules=false
+  - https://github.com/opendatahub-io/kubeflow//components/odh-notebook-controller/config/base?ref=v1.10.0-5&submodules=false
   - culler-config.yaml
 
 patches:


### PR DESCRIPTION
## Summary

Fixes #55, and along the way found and fixed a second, related version-pin bug in the same test flow.

### Fix 1: `data-science-pipelines-operator` (DSPO) pinned to `v2.18.0` instead of `v2.15.1`

`components/03-kf-pipelines.yaml` pinned DSPO to `v2.18.0` — three ODH releases ahead of what RHOAI 2.25 (this repo's actual baseline, per [opendatahub-community#183](https://github.com/opendatahub-io/opendatahub-community/issues/183#issuecomment-3351838012)) ships. `v2.18.0` renamed the DSPA's OpenShift-auth sidecar from `oauth-proxy` to `kube-rbac-proxy`, which broke things two ways:

1. The new `kube-rbac-proxy` image is a `registry.redhat.io` reference our kind cluster can't authenticate to → permanent `ImagePullBackOff` on every DSPA's `ds-pipeline-*` / `ds-pipeline-metadata-envoy-*` pods.
2. Even once pulling, `ods-ci`'s `release-2.25` suite (`Verify Pipeline Server Deployments` in `DataSciencePipelinesBackend.resource`) asserts the sidecar container is literally named `oauth-proxy` — a hard-coded name mismatch that fails independently of (1).

**The fix is a one-line version pin**, `v2.18.0` → `v2.15.1` (what RHOAI 2.25 really ships). `v2.15.1` still uses `oauth-proxy`, which `components/03-kf-pipelines.yaml` already mirrors via `IMAGES_OAUTHPROXY` — no new image override needed.

### Fix 2: `notebook-controller` / `odh-notebook-controller` pinned to `v1.10.0-6` instead of `v1.10.0-5`

With Fix 1 in place, the same test progressed further and hit a new failure: `Verify Pipeline Server Deployments` now failed because the Elyra pipeline-runtime-config dropdown had no `"Data Science Pipeline"` option in the JupyterLab "Run pipeline" dialog. Root cause: `odh-notebook-controller` creates the `ds-pipeline-config` secret (the Elyra runtime config JSON) for every DSPA-enabled project, and the pinned tag `v1.10.0-6` already contains [RHOAIENG-32633](https://issues.redhat.com/browse/RHOAIENG-32633) ("Rename the ref Data Science Pipeline to AI Pipeline in Kubeflow") — a change whose Jira **target version is `rhoai-3.0`**, not 2.25. It merged to `opendatahub-io/kubeflow` main on 2025-09-23, three days before the community tag `v1.10.0-6` was cut (2025-09-26) and swept it in, even though it was never meant to ship in the RHOAI 2.x line.

Confirmed directly against the real downstream `red-hat-data-services/kubeflow` `rhoai-2.25` branch: both `notebook-controller` and `odh-notebook-controller` are pinned there to **`v1.10.0-5`**, and that build's `notebook_dspa_secret.go` still says `"Data Science Pipeline"` — matching exactly what `ods-ci`'s `release-2.25` suite expects.

**The fix is the same shape as Fix 1**: `v1.10.0-6` → `v1.10.0-5` in `components/09-kf-notebooks/kustomization.yaml`, for both the `notebook-controller` and `odh-notebook-controller` kustomize sources.

## Test plan

- [x] Fix 1: reproduced the exact CI failure locally (unpatched `v2.18.0` → `ImagePullBackOff` on `kube-rbac-proxy`, `401` from `registry.redhat.io`); applied the pin; confirmed all DSPA pods reach `Running`, including a correctly-named `oauth-proxy` (`2/2`, 0 restarts), in a namespace properly labeled `opendatahub.io/dashboard: "true"` (matching how ods-ci/the Dashboard actually creates project namespaces).
- [x] Fix 2: reproduced locally by driving the Dashboard + a real workbench through Chrome DevTools MCP and running the actual `0502__ide_elyra.robot` suite; confirmed the `ds-pipeline-config` secret said `"AI Pipeline"` under `v1.10.0-6`; applied the `v1.10.0-5` pin; confirmed the secret flipped to `"Data Science Pipeline"` (both controllers reconciled it in place, no need to recreate the DSPA).
- [ ] CI: the `rhoai-in-kind (v1.36.0, tests/Tests/0500__ide/0502__ide_elyra.robot)` ods-ci job is the one that originally failed in #55 — should now pass through both the pipeline-server-deployment check and the Elyra runtime-config check.

<details>
<summary>Session trajectory (click to expand) — includes two dead ends and two false starts, all corrected along the way</summary>

This PR went through several phases before landing on both real fixes. Recording the wrong turns since they're informative — several of my own working hypotheses turned out to be wrong and were caught and corrected along the way, sometimes by the user, sometimes by going back to primary sources.

**Phase 1 — chased the wrong root cause for #55 (kube-rbac-proxy image mirror).**
1. Read issue #55 and CodeRabbit's analysis, which correctly identified `kube-rbac-proxy`'s `registry.redhat.io` image as the proximate cause and suggested overriding env var `IMAGES_KUBE_RBAC_PROXY`.
2. Applied that suggested override, redeployed, and reproduced the *original* bug from scratch first (unpatched operator → `ImagePullBackOff`, confirmed). Redeployed with the fix — **it didn't work**: pods still pulled the original `registry.redhat.io` image.
3. Traced DSPO's Go source (`controllers/dspipeline_params.go`, `controllers/config/defaults.go`, `main.go`) and found DSPO's viper config maps `Images.KubeRBACProxy` → env var `IMAGES_KUBERBACPROXY` (no separating underscores) — DSPO's own `manager.yaml` (and CodeRabbit's suggestion, copied from it) uses `IMAGES_KUBE_RBAC_PROXY`, which viper never matches. Verified the correct name empirically via `kubectl set env` before trusting it.
4. Hit a second, environment-specific snag: the chosen mirror `quay.io/openshift/origin-kube-rbac-proxy` is amd64-only, so it failed with `no match for platform in manifest` on the local arm64 (Apple Silicon) kind node. Switched to `quay.io/brancz/kube-rbac-proxy` (the multi-arch upstream project Red Hat's image rebuilds) and confirmed it pulls and runs cleanly end-to-end (all pods `Running`, `2/2`).
5. At this point the fix "worked" in the narrow sense — but it was fixing the wrong version.

**Phase 2 — found the real root cause for #55 (version pin).**
6. Ran the *actual* CI job against this branch. It failed differently: `ods-ci`'s `Verify Pipeline Server Deployments` now failed on `Lists are different: Index 1: kube-rbac-proxy != oauth-proxy` — a container-*name* assertion, not an image-pull problem. The reporter's own hunch ("looks like we're pulling too new a version of pipelines?") turned out to be exactly right.
7. Checked `opendatahub-community#183` (the release tracker for the ODH version matching this repo's pinned `workbench v1.36.0`) and confirmed it pins DSPO to `v2.15.1`, not `v2.18.0`. Bisected DSPO tags to find `v2.18.0` was the first version to rename `oauth-proxy` → `kube-rbac-proxy` (`v2.17.0` still used `oauth-proxy`; there is no `v2.16.0` tag at all — confirmed via `gh api` against tags/releases/branches that it was simply never published, not hidden).
8. Reverted the `kube-rbac-proxy` mirror entirely (unnecessary at `v2.15.1` — that version doesn't have the key) and changed just the `targetRevision` pin to `v2.15.1`.

**Phase 3 — a false alarm on the way to full verification of #55.**
9. Redeployed and recreated the DSPA — `oauth-proxy` came up `CrashLoopBackOff`, failing to read `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. Initially guessed this was an artifact of the ad-hoc test namespace. **The user pushed back, correctly, twice**: first questioning whether a working `oauth-proxy` was even required for the test to pass (traced the `Verify Deployment` keyword's Robot Framework source and confirmed it does explicitly assert `state[0] == running` per container, so yes, it's required); second questioning whether the repo's existing custom `quay.io/jdanek/origin-oauth-proxy` image (which patches OAuth login URLs) already handled this (confirmed via the live pod spec that it doesn't and structurally can't — the failing `--upstream-ca=...` flag is generated entirely by DSPO's own code and appended after the image's baked-in flags).
10. While investigating, the user pointed at a downloaded CI debug bundle (`grab/ci-debug-bundle/.../clusterpolicies.yaml`) showing a Kyverno policy, `set-serviceaccount-volume-mounts`, that mutates pods to project the namespace's `openshift-service-ca.crt` ConfigMap into exactly that file path — solving the problem I'd assumed was unsolved. It's scoped to `namespaceSelector: matchLabels: opendatahub.io/dashboard: "true"`, a label my hand-created test namespace lacked (real Data-Science-Project namespaces, as created by the Dashboard/ods-ci, get it automatically).
11. Recreated the test namespace with that label — **all pods came up `Running`, including `oauth-proxy`, 2/2, zero restarts.** The DSPO version pin alone is the complete fix for #55; no additional polyfill work needed.

**Phase 4 — a second, independent version-pin bug found by pushing CI further.**
12. With #55 fixed, the same CI job progressed and failed again — but on a *new*, previously-undocumented error: the Elyra "Run pipeline" dialog's runtime-config dropdown had no `"Data Science Pipeline"` option. Searched for an existing tracked issue (upstream `ods-ci`, `opendatahub-io/notebooks`, `elyra-ai/elyra`, this repo) and found none.
13. Reproduced locally end-to-end: brought up the stack, drove the real Dashboard UI via Chrome DevTools MCP (project creation, S3 connection, pipeline server, workbench spawn) in parallel with running the actual `run_robot_test.sh`-equivalent robot invocation for `0502__ide_elyra.robot` directly against the local cluster. Confirmed the dropdown had exactly one option, but it said **`"AI Pipeline"`**, not `"Data Science Pipeline"`.
14. Traced the generated `ds-pipeline-config` secret's `odh_dsp.json` and **initially misattributed its creation to odh-dashboard's frontend** (`frontend/src/concepts/pipelines/elyra/utils.ts`, which does contain matching-looking code with `display_name: 'Data Science Pipeline'`) — a real but unused/legacy code path. **Corrected this** by consulting the official RHOAI 2.25 architecture doc (`architecture-context/architecture/rhoai-2.25/kubeflow.md`), which explicitly attributes the `ds-pipeline-config` secret to **`odh-notebook-controller`** (config flag `SET_PIPELINE_SECRET`), then confirmed directly in `odh-notebook-controller`'s own source (`notebook_dspa_secret.go`) at the exact pinned tag `v1.10.0-6`.
15. Found the renaming commit (`opendatahub-io/kubeflow` PR #687, `RHOAIENG-32633`) and, from its merge date (2025-09-23) versus the community tag's cut date (2025-09-26), **initially concluded** the rename must have been intentionally part of the ODH 2.35.0/rhoai-2.25 release. **The user caught this being wrong**: RHOAIENG-32633's actual Jira **target/fix version is `rhoai-3.0`**, not 2.25, with a Red Hat release-hygiene bot comment flagging the ticket's own version metadata as inconsistent — a reminder that a commit landing on an open-source `main` branch before a community tag is cut doesn't mean it was scoped for that downstream release.
16. Investigated whether `opendatahub-io/kubeflow` has separate long-lived branches for downstream tracking (per the user's suggestion) and found `stable-2.x`, whose current `params.env` pins both controllers to `v1.10.0-4` (pre-rename) — but then, per the user's request, checked the actual **`red-hat-data-services/kubeflow` `rhoai-2.25`** branch directly (the real downstream source), which pins both controllers to **`v1.10.0-5`** — one patch tag later than `stable-2.x`, and also pre-rename.
17. Applied the `v1.10.0-6` → `v1.10.0-5` pin, redeployed, and confirmed the *existing* DSPA's `ds-pipeline-config` secret reconciled in place from `"AI Pipeline"` back to `"Data Science Pipeline"` — no need to recreate anything.

</details>
