### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,18 @@ non-obvious gotcha found along the way. -->
 - [ ] ... (CI)
 
 <details>
-<summary>Investigation trajectory (optional — delete if trivial)</summary>
+<summary>Plan</summary>
 
-Approved plan and notable dead ends go here.
+The approved plan for this change goes here.
+
+</details>
+
+<details>
+<summary>Trajectory</summary>
+
+The full investigation trajectory goes here — every step taken, including dead ends and
+reverted approaches, in full and unabridged. Do not summarize or omit steps as
+"not notable."
 
 </details>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,9 +28,9 @@ The approved plan for this change goes here.
 <details>
 <summary>Trajectory</summary>
 
-The full investigation trajectory goes here — every step taken, including dead ends and
-reverted approaches, in full and unabridged. Do not summarize or omit steps as
-"not notable."
+The full trajectory goes here — every step of investigating, implementing, and testing the
+fix, including dead ends and reverted approaches, in full and unabridged. Do not summarize
+or omit steps as "not notable."
 
 </details>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- 1-3 sentences: what changed and why. -->
+
+## Root cause
+
+<!-- Delete this section if this isn't a bug fix. What was actually broken, why, and any
+non-obvious gotcha found along the way. -->
+
+## Related issue
+
+<!-- e.g. RHOAIENG-XXXXX, or Fixes #NN. Delete if not applicable. -->
+
+## Test plan
+
+<!-- Check off what you actually verified locally; mark what's left to CI. -->
+
+- [ ] ...
+- [ ] ... (CI)
+
+<details>
+<summary>Investigation trajectory (optional — delete if trivial)</summary>
+
+Approved plan and notable dead ends go here.
+
+</details>
+
+---
+
+- [ ] Tests run locally
+- [ ] No unrelated changes bundled in
+- [ ] Commit messages describe the why

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,21 +21,15 @@ non-obvious gotcha found along the way. -->
 <details>
 <summary>Plan</summary>
 
-The approved plan for this change goes here.
+<!-- The approved plan for this change goes here. -->
 
 </details>
 
 <details>
 <summary>Trajectory</summary>
 
-The full trajectory goes here — every step of investigating, implementing, and testing the
-fix, including dead ends and reverted approaches, in full and unabridged. Do not summarize
-or omit steps as "not notable."
+<!-- The full trajectory goes here — every step of investigating, implementing, and testing
+the fix, including dead ends and reverted approaches, in full and unabridged. Do not
+summarize or omit steps as "not notable." -->
 
 </details>
-
----
-
-- [ ] Tests run locally
-- [ ] No unrelated changes bundled in
-- [ ] Commit messages describe the why


### PR DESCRIPTION
## Summary

Adds `.github/pull_request_template.md` so new PRs get a lightweight scaffold instead of a blank description box.

## Related issue

N/A

## Test plan

- [x] Rendered the raw markdown locally to confirm the `<details>` block and checkboxes format correctly
- [x] This PR's own description was written using the new template as a dry run

---

- [x] Tests run locally
- [x] No unrelated changes bundled in
- [x] Commit messages describe the why

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pull request template with sections for summaries, root causes, related issues, testing details, investigation notes, and contributor verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->