### PR TITLE
ci: split elyra matrix entry per test, pre-pull images to fix TrustyAI spawn timeout

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -75,13 +75,9 @@ jobs:
           # Test B (Tier1, templated over PyTorch/TensorFlow/TrustyAI images): fails because
           # the TrustyAI image's cold pull can take ~5 minutes under CI I/O load, blowing the
           # robot test's fixed 5-minute workbench-spawn timeout. See
-          # https://github.com/jiridanek/rhoai-in-kind/issues/67
-          # A DevSpaces-like DaemonSet image-puller (RHOAIENG-56335) was considered instead of
-          # this ad-hoc pre-pull and rejected: that mechanism only helps on multi-node
-          # autoscaling, where a racing puller pod and workload pod land on a new node
-          # together; this kind cluster is one static node that already exists before the test
-          # runs, so `kind load docker-image` (which injects the image directly, no pull at
-          # all) is simpler and strictly sufficient here.
+          # https://github.com/jiridanek/rhoai-in-kind/issues/67 - fixed via the
+          # image-puller DaemonSet steps below (see their comments for the RHOAIENG-56335 /
+          # che-incubator/kubernetes-image-puller background).
           # CAUTION: image tags are pinned to the job's WORKBENCH_BRANCH env above; keep in sync.
           - test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
             artifact_suffix: "tier1"
@@ -177,34 +173,102 @@ jobs:
       - name: Verify kubectl version
         run: kubectl version --client
 
+      # In-cluster image pre-pull via a DaemonSet, per the general approach from
+      # RHOAIENG-56335 ("Increase in session startup due to latest image pull") and implemented
+      # by che-incubator/kubernetes-image-puller (the tool behind Red Hat OpenShift Dev
+      # Spaces's image pre-pull): each container runs `sleep 720h` on the target image itself,
+      # which (a) makes the node's own containerd pull the image directly from the registry -
+      # one hop, unlike `docker pull` + `kind load docker-image`'s pull-then-copy - and
+      # (b) keeps a real running container referencing the image, so kubelet's image GC won't
+      # evict it again under disk pressure (relevant here, see issue #67) the way a one-shot
+      # pull-and-exit container would risk.
+      #
+      # ✘ Istiod encountered an error: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
+      #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")Error: failed to install manifests: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
+      #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")
+      # This must run (and be waited on, below) before "Deploy stuff into Kubernetes", since
+      # that step's `istioctl install` synchronously waits for istiod itself - a pre-pull step
+      # placed after that one (as this used to be) cannot help the failure above at all: GitHub
+      # Actions steps never overlap, so by the time a later step starts, istioctl has already
+      # finished waiting (or already failed).
+      # CAUTION: the image tag is likely to go out of date, try to keep in sync
+      - name: Pre-pull istio image via image-puller DaemonSet
+        run: |
+          set -Eeuxo pipefail
+          cat <<EOF | kubectl apply -f -
+          apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: image-puller-istio
+            namespace: kube-system
+            labels:
+              app: image-puller-istio
+          spec:
+            selector:
+              matchLabels:
+                app: image-puller-istio
+            template:
+              metadata:
+                labels:
+                  app: image-puller-istio
+              spec:
+                tolerations:
+                  - operator: Exists
+                containers:
+                  - name: istio-pilot
+                    image: docker.io/istio/pilot:1.25.1
+                    command: ["sleep", "720h"]
+          EOF
+
+      - name: Wait for istio image-puller DaemonSet to be ready
+        run: kubectl rollout status daemonset/image-puller-istio -n kube-system --timeout=600s
+
+      # Same in-cluster image-puller mechanism as above, for images a matrix entry declares via
+      # `prepull_images` (large workbench/runtime images that can otherwise cold-pull slowly
+      # enough under CI I/O load to blow a robot test's fixed spawn timeout - see issue #67).
+      # No-op for entries without prepull_images. Only creates the DaemonSet here - the
+      # blocking wait for it happens later, right before "Run ods-ci tests", so the pull runs
+      # in the background, overlapping with the rest of this job's setup (deploy.py, Poetry,
+      # oc login) instead of costing extra wall-clock time on top of it.
+      - name: Pre-pull matrix-specified images via image-puller DaemonSet
+        if: matrix.prepull_images
+        run: |
+          set -Eeuxo pipefail
+          containers=""
+          i=0
+          for image in ${{ matrix.prepull_images }}; do
+            containers="${containers}
+                  - name: img-${i}
+                    image: \"${image}\"
+                    command: [\"sleep\", \"720h\"]"
+            i=$((i + 1))
+          done
+          cat <<EOF | kubectl apply -f -
+          apiVersion: apps/v1
+          kind: DaemonSet
+          metadata:
+            name: image-puller-prepull
+            namespace: kube-system
+            labels:
+              app: image-puller-prepull
+          spec:
+            selector:
+              matchLabels:
+                app: image-puller-prepull
+            template:
+              metadata:
+                labels:
+                  app: image-puller-prepull
+              spec:
+                tolerations:
+                  - operator: Exists
+                containers:${containers}
+          EOF
+
       - name: Deploy stuff into Kubernetes
         run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
         env:
           PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
-
-      # ✘ Istiod encountered an error: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
-      #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")Error: failed to install manifests: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
-      #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")
-      # CAUTION: the image tag is likely to go out of date, try to keep in sync
-      - name: Pre-pull istio inside kind cluster
-        run: |
-          set -Eeuxo pipefail
-          timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.25.1; do sleep 1; done'
-          kind load docker-image docker.io/istio/pilot:1.25.1
-
-      # Pre-pulls large workbench/runtime images a matrix entry declares via `prepull_images`,
-      # straight into the kind node's containerd - avoids cold registry pulls racing a robot
-      # test's fixed spawn timeout under CI I/O load. No-op for entries without prepull_images.
-      - name: Pre-pull matrix-specified images inside kind cluster
-        if: matrix.prepull_images
-        run: |
-          set -Eeuxo pipefail
-          for image in ${{ matrix.prepull_images }}; do
-            # Observed worst case for a large workbench image under CI I/O load is ~5m0s
-            # (see issue #67); use a generous margin rather than cutting it close.
-            timeout 600s bash -c "while ! docker pull '$image'; do sleep 1; done"
-            kind load docker-image "$image"
-          done
 
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
@@ -233,6 +297,14 @@ jobs:
 
       - name: Prepare test-variables.yml
         run: mv components/ods-ci/test-variables.yml ods-ci/ods_ci/test-variables.yml
+
+      # The DaemonSet was created way back before "Deploy stuff into Kubernetes"; by now it's
+      # had the whole deploy/Poetry/oc-login setup's worth of wall-clock time to pull in the
+      # background, so this should return near-instantly. This is the actual guarantee that
+      # the images are cached before the robot test below tries to spawn a workbench with one.
+      - name: Wait for matrix-specified image-puller DaemonSet to be ready
+        if: matrix.prepull_images
+        run: kubectl rollout status daemonset/image-puller-prepull -n kube-system --timeout=600s
 
       # NOTE: Tests in ods-ci often depend on what's before them in the file, so it's best to run file-by-file
       - name: Run ods-ci tests

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   rhoai-in-kind:
     name: >-
-      rhoai-in-kind (${{ env.WORKBENCH_BRANCH }}, ${{ matrix.test_case }}${{ matrix.artifact_suffix && format(' [{0}]', matrix.artifact_suffix) || '' }})
+      rhoai-in-kind (${{ matrix.test_case }}${{ matrix.artifact_suffix && format(' [{0}]', matrix.artifact_suffix) || '' }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -14,14 +14,20 @@ permissions: {}
 jobs:
   rhoai-in-kind:
     name: >-
-      rhoai-in-kind (${{ matrix.workbench_branch }}, ${{ matrix.test_case }}${{ matrix.artifact_suffix && format(' [{0}]', matrix.artifact_suffix) || '' }})
+      rhoai-in-kind (${{ env.WORKBENCH_BRANCH }}, ${{ matrix.test_case }}${{ matrix.artifact_suffix && format(' [{0}]', matrix.artifact_suffix) || '' }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Not a matrix axis: every entry below uses the same workbench_branch today, and since
+      # the matrix is include:-only (see below), a second value would need every entry
+      # duplicated anyway rather than getting an automatic cross-product - so there's no
+      # benefit to carrying it as a per-entry field. Bump this single value when needed.
+      WORKBENCH_BRANCH: v1.36.0
 
     strategy:
       fail-fast: false
-      # Every entry is a self-contained job spec (workbench_branch + test_case + optional
+      # Every entry is a self-contained job spec (test_case + optional
       # extra_robot_args/prepull_images/artifact_suffix) rather than a flat `test_case:` axis,
       # so that two entries can share the same test_case (see the split elyra entries below)
       # without relying on GitHub Actions' include/axis merge semantics, which only merge an
@@ -29,37 +35,23 @@ jobs:
       # and easy to get wrong once entries need heterogeneous optional fields.
       matrix:
         include:
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
 
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
@@ -77,8 +69,7 @@ jobs:
           # this file's Suite Setup/Teardown, so each entry re-runs that (~1-2min extra, ok).
           #
           # Test A (Sanity, single image) already passes reliably - no pre-pull needed.
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
+          - test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
             artifact_suffix: "sanity"
             extra_robot_args: "-i Sanity"
           # Test B (Tier1, templated over PyTorch/TensorFlow/TrustyAI images): fails because
@@ -91,9 +82,8 @@ jobs:
           # together; this kind cluster is one static node that already exists before the test
           # runs, so `kind load docker-image` (which injects the image directly, no pull at
           # all) is simpler and strictly sufficient here.
-          # CAUTION: image tags are pinned to workbench_branch v1.36.0 above; keep in sync.
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
+          # CAUTION: image tags are pinned to the job's WORKBENCH_BRANCH env above; keep in sync.
+          - test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
             artifact_suffix: "tier1"
             extra_robot_args: "-i Tier1"
             prepull_images: >-
@@ -103,8 +93,7 @@ jobs:
               quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
 
           # my env does make everyone cluster-admin, so perms tests are meaningless
-          - workbench_branch: v1.36.0
-            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
+          - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
           # TODO: 9) error: the server doesn't have a resource type "group": 1 != 0
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot"
 
@@ -189,7 +178,7 @@ jobs:
         run: kubectl version --client
 
       - name: Deploy stuff into Kubernetes
-        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ matrix.workbench_branch }}
+        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
         env:
           PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -24,6 +24,14 @@ jobs:
       # duplicated anyway rather than getting an automatic cross-product - so there's no
       # benefit to carrying it as a per-entry field. Bump this single value when needed.
       WORKBENCH_BRANCH: v1.36.0
+      # The actual quay.io image tag for WORKBENCH_BRANCH's workbench/runtime images - related
+      # but distinct from the branch ref above (kustomize checkout ref vs. registry tag) and not
+      # mechanically derivable from it (re-derive both from a fresh run's cluster-logs when
+      # bumping, per the CAUTION comment below), so kept as its own constant. matrix.include
+      # entries can't reference the env context directly (same restriction that keeps this out
+      # of the job name above), so each prepull_images entry uses the literal placeholder "TAG"
+      # instead, substituted at runtime in the pre-pull steps' Python.
+      NOTEBOOK_IMAGE_TAG: 2025b-v1.36
 
     strategy:
       fail-fast: false
@@ -39,34 +47,37 @@ jobs:
         # cluster-logs artifact from a full matrix run (32538812359), not by reading test source -
         # by the time cluster-logs is collected the workbench pod is often already torn down, so
         # eventss.yaml (which retains pull events after pod deletion) is the reliable source.
-        # CAUTION: 2025b-v1.36-tagged images are pinned to the job's WORKBENCH_BRANCH env above;
-        # keep in sync if that version bumps - re-derive from a fresh run's cluster-logs rather
-        # than guessing, since the notebooks repo's own manifests/base kustomize still has
-        # unresolved "-n_PLACEHOLDER" build-time placeholders for the current (n) image tags.
+        # CAUTION: entries using the "TAG" placeholder (substituted at runtime from
+        # env.NOTEBOOK_IMAGE_TAG) are pinned to the job's WORKBENCH_BRANCH above; keep both in
+        # sync if that version bumps - re-derive from a fresh run's cluster-logs rather than
+        # guessing, since the notebooks repo's own manifests/base kustomize still has unresolved
+        # "-n_PLACEHOLDER" build-time placeholders for the current (n) image tags. Entries
+        # pinned by @sha256 digest (multiple-image-tags.robot) or a hardcoded unrelated tag
+        # (custom-image.robot) don't use the placeholder and are unaffected by either bump.
         include:
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:TAG
           # Not WORKBENCH_BRANCH-linked: this test imports a hardcoded custom/BYON image by URL
           # (see custom-image.robot's ${IMG_URL}), unrelated to the odh-notebooks release train.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
             prepull_images: quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.11-2024b-20241004
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:TAG
 
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:TAG
           # Iterates over last release's (n-1, py311) images specifically - digest-pinned since
           # that's how the notebooks repo's own params.env pins n-1, and there's no tag to track.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
@@ -79,17 +90,17 @@ jobs:
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot"
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           # Exercises 5 workbench image flavors in one file.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
             prepull_images: >-
-              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:TAG
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:TAG
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
@@ -112,9 +123,9 @@ jobs:
             artifact_suffix: "sanity"
             extra_robot_args: "-i Sanity"
             prepull_images: >-
-              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:TAG
           # Test B (Tier1, templated over PyTorch/TensorFlow/TrustyAI images): fails because
           # the TrustyAI image's cold pull can take ~5 minutes under CI I/O load, blowing the
           # robot test's fixed 5-minute workbench-spawn timeout. See
@@ -143,25 +154,15 @@ jobs:
             artifact_suffix: "tier1"
             extra_robot_args: "-i Tier1"
             prepull_images: >-
-              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
-              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
-              quay.io/fedora/mariadb-103:latest
-              quay.io/opendatahub/ds-pipelines-api-server@sha256:b5b9d057d7551ac184a6491b393d32e2e3ac2a9696697e25a64429fc4f4ed046
-              quay.io/opendatahub/ds-pipelines-persistenceagent@sha256:4b8316a8878c0d36b8d2297ed9f273fb0e6ffe0433fa24e908686a6f0888f919
-              quay.io/opendatahub/ds-pipelines-scheduledworkflow@sha256:80be2933c89ab9639c2ad189dfaf7a0566e22487d08ad5983197e6d4433692ce
-              quay.io/opendatahub/ds-pipelines-argo-workflowcontroller@sha256:995f06328569b558d63cf727c0674df71b1927f74ab60e966596ccb8c06e12f8
-              quay.io/opendatahub/ds-pipelines-argo-argoexec@sha256:da1b0d502ae97160185ec5debc2f0c8d54f70b01be4ea4a9339d7137cc3918a9
-              quay.io/opendatahub/ds-pipelines-driver@sha256:4fefd903a775916632f3eb59706ecbea902b1961bcb1e20e142b06672cebfd61
-              quay.io/opendatahub/ds-pipelines-launcher@sha256:48b68a2e888722021721e6f4c60e6a76eedd530b11df796b32fe04c8b01636d5
-              quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:973ed0a2812215e0ed43817f70adf6a90ef808215186005c66d40b482eafc968
-              quay.io/opendatahub/mlmd-grpc-server@sha256:9e905b2de2fb6801716a14ebd6e589cac82fef26741825d06717d695a37ff199
+              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
+              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:TAG
 
           # my env does make everyone cluster-admin, so perms tests are meaningless
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
-            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:TAG
           # TODO: 9) error: the server doesn't have a resource type "group": 1 != 0
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot"
 
@@ -299,28 +300,79 @@ jobs:
       - name: Wait for istio image-puller DaemonSet to be ready
         run: kubectl rollout status daemonset/image-puller-istio -n kube-system --timeout=600s
 
-      # Same in-cluster image-puller mechanism as above, for images a matrix entry declares via
-      # `prepull_images` (large workbench/runtime images that can otherwise cold-pull slowly
-      # enough under CI I/O load to blow a robot test's fixed spawn timeout - see issue #67).
-      # No-op for entries without prepull_images. Only creates the DaemonSet here - the
-      # blocking wait for it happens later, right before "Run ods-ci tests", so the pull runs
-      # in the background, overlapping with the rest of this job's setup (deploy.py, Poetry,
-      # oc login) instead of costing extra wall-clock time on top of it.
+      # Phase 1 of a two-phase pre-pull for images a matrix entry declares via `prepull_images`
+      # (large workbench/runtime images that can otherwise cold-pull slowly enough under CI I/O
+      # load to blow a robot test's fixed spawn timeout - see issue #67). No-op for entries
+      # without prepull_images.
       #
-      # Placed *before* "Deploy stuff into Kubernetes", same as the istio pre-pull above: this
-      # used to run after deploy.py instead, because with kubelet's default one-pull-at-a-time
-      # FIFO queue, this DaemonSet's ~35GB of large images pulling concurrently starved
-      # cert-manager/ArgoCD/Kyverno's own small, normally-instant pulls badly enough that
-      # deploy.py's `kubectl wait ... cert-manager` timed out after 5 minutes - see PR #72 CI
-      # run 32532246937. Now that components/00-kind-cluster.yaml sets
-      # maxParallelImagePulls: 6, deploy.py's small pulls can get a concurrent slot instead of
-      # queuing strictly behind these, so pre-pulling can start immediately and overlap with
-      # deploy.py's own runtime too.
-      # One DaemonSet per image, not one DaemonSet with N sibling containers: kubelet's pod
-      # worker starts a single pod's own containers sequentially regardless of the node's
-      # maxParallelImagePulls setting (see components/00-kind-cluster.yaml) - that setting only
-      # allows concurrency *across* pods. Separate pods actually let multiple of these pulls run
-      # at once instead of strictly one-at-a-time.
+      # This phase deliberately uses ONE DaemonSet with N sibling containers (the shape phase 2
+      # below avoids), fired-and-forgotten before "Deploy stuff into Kubernetes" with no wait
+      # step at all. That single-pod shape means kubelet's pod worker starts its containers
+      # strictly sequentially - so this phase only ever has *one* image pull in flight, occupying
+      # a single one of the node's maxParallelImagePulls admission slots (see
+      # components/00-kind-cluster.yaml) no matter how many images are listed. That's the whole
+      # point: deploy.py's own pulls (cert-manager, ArgoCD, Kyverno, ...) still get the rest of
+      # those slots immediately instead of queuing behind a burst of background pulls that all
+      # arrived first. Whatever this phase manages to pull during deploy.py's ~350s runtime is
+      # free - the images it doesn't get to in time are caught by phase 2 below.
+      #
+      # This was tried the other way first (one DaemonSet *per* image, fired before deploy.py,
+      # so all N pulls could race for maxParallelImagePulls slots at once): with tier1's image
+      # list that measured a 1-in-5 rate of deploy.py itself timing out - ArgoCD's own image took
+      # 4.5 minutes just to reach the front of the pull queue, eating almost all of its 180s
+      # `kubectl wait` budget before the pull had even started. See pulling_timings.md.
+      - name: Pre-pull matrix-specified images sequentially (best-effort, before deploy.py)
+        if: matrix.prepull_images
+        shell: python {0}
+        # language: python
+        run: |
+          import json
+          import os
+          import subprocess
+
+          images = os.environ["PREPULL_IMAGES"].replace("TAG", os.environ["NOTEBOOK_IMAGE_TAG"]).split()
+          name = "image-puller-prepull-sequential"
+          manifest = {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                  "name": name,
+                  "namespace": "kube-system",
+                  "labels": {"app": name},
+              },
+              "spec": {
+                  "selector": {"matchLabels": {"app": name}},
+                  "template": {
+                      "metadata": {"labels": {"app": name}},
+                      "spec": {
+                          "tolerations": [{"operator": "Exists"}],
+                          "containers": [
+                              {"name": f"img-{i}", "image": image, "command": ["sleep", "720h"]}
+                              for i, image in enumerate(images)
+                          ],
+                      },
+                  },
+              },
+          }
+          subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
+        env:
+          PREPULL_IMAGES: ${{ matrix.prepull_images }}
+          NOTEBOOK_IMAGE_TAG: ${{ env.NOTEBOOK_IMAGE_TAG }}
+
+      - name: Deploy stuff into Kubernetes
+        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
+        env:
+          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
+
+      # Phase 2 of the two-phase pre-pull (see phase 1's comment above): one DaemonSet *per*
+      # image now, so up to maxParallelImagePulls of them can pull concurrently - safe here
+      # because deploy.py's own readiness waits are already done, so there's nothing left for
+      # these background pulls to starve. Re-requesting an image phase 1 already finished is a
+      # fast no-op (content-addressed image store reports it already present, no re-download);
+      # anything phase 1 hadn't reached yet gets its first real pull request here instead.
+      # Only creates the DaemonSets here - the blocking wait for them happens later, right
+      # before "Run ods-ci tests", so this still overlaps with Poetry/oc-login/test-variables
+      # instead of adding pure wall-clock time on top of them.
       - name: Pre-pull matrix-specified images via image-puller DaemonSet
         if: matrix.prepull_images
         shell: python {0}
@@ -330,7 +382,7 @@ jobs:
           import os
           import subprocess
 
-          images = os.environ["PREPULL_IMAGES"].split()
+          images = os.environ["PREPULL_IMAGES"].replace("TAG", os.environ["NOTEBOOK_IMAGE_TAG"]).split()
           for i, image in enumerate(images):
               name = f"image-puller-prepull-{i}"
               manifest = {
@@ -355,11 +407,7 @@ jobs:
               subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
         env:
           PREPULL_IMAGES: ${{ matrix.prepull_images }}
-
-      - name: Deploy stuff into Kubernetes
-        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
-        env:
-          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
+          NOTEBOOK_IMAGE_TAG: ${{ env.NOTEBOOK_IMAGE_TAG }}
 
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
@@ -389,11 +437,13 @@ jobs:
       - name: Prepare test-variables.yml
         run: mv components/ods-ci/test-variables.yml ods-ci/ods_ci/test-variables.yml
 
-      # The DaemonSets were created right before "Deploy stuff into Kubernetes"; by now they've
-      # had deploy.py's own runtime plus the Poetry/oc-login/test-variables setup's worth of
-      # wall-clock time to pull in the background, so this should return quickly. This is the
-      # actual guarantee that the images are cached before the robot test below tries to spawn
-      # a workbench with one.
+      # Blocks on phase 2's per-image DaemonSets only (created right after "Deploy stuff into
+      # Kubernetes"); by now they've had the Poetry/oc-login/test-variables setup's worth of
+      # wall-clock time to pull in the background on top of that, so this should return quickly.
+      # Phase 1's sequential DaemonSet (fired-and-forgotten before deploy.py) is never waited on
+      # directly - whatever it already pulled just makes phase 2's requests for the same images
+      # instant no-ops. This step is the actual guarantee that every image is cached before the
+      # robot test below tries to spawn a workbench with one.
       #
       # `kubectl rollout status` only reports pod-count-level state (how many nodes have the
       # pod, how many are Available) - it wouldn't otherwise print anything for the whole wait.

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -34,24 +34,62 @@ jobs:
       # include entry into a generated combination when its keys match *all* axes - ambiguous
       # and easy to get wrong once entries need heterogeneous optional fields.
       matrix:
+        # prepull_images below were discovered the same way as the elyra entries further down:
+        # by reading the actual pod specs / events (podss.yaml, eventss.yaml) in each job's own
+        # cluster-logs artifact from a full matrix run (32538812359), not by reading test source -
+        # by the time cluster-logs is collected the workbench pod is often already torn down, so
+        # eventss.yaml (which retains pull events after pod deletion) is the reliable source.
+        # CAUTION: 2025b-v1.36-tagged images are pinned to the job's WORKBENCH_BRANCH env above;
+        # keep in sync if that version bumps - re-derive from a fresh run's cluster-logs rather
+        # than guessing, since the notebooks repo's own manifests/base kustomize still has
+        # unresolved "-n_PLACEHOLDER" build-time placeholders for the current (n) image tags.
         include:
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-codeserver-datascience-cpu-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
+          # Not WORKBENCH_BRANCH-linked: this test imports a hardcoded custom/BYON image by URL
+          # (see custom-image.robot's ${IMG_URL}), unrelated to the odh-notebooks release train.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
+            prepull_images: quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.11-2024b-20241004
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
 
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+          # Iterates over last release's (n-1, py311) images specifically - digest-pinned since
+          # that's how the notebooks repo's own params.env pins n-1, and there's no tag to track.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
+            prepull_images: >-
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py311-ubi9@sha256:45ec6fc94d5f0eb1efff548687f4beacb2f5c4a1bef78a38b9475e1583536d7d
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py311-ubi9@sha256:b23028134c94c2392a74b89e62dc7f2b5223b15e1c1fb691c6c39a36a4149ee5
+              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py311-ubi9@sha256:97ac518d5982f0ad438b6c33f36162715be651fb4dbe1a80f972712997c0de22
+              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py311-ubi9@sha256:b9245c43060321b3cb8261fee538765e1debe43e5546103fa30a7c61fdaec032
+              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py311-ubi9@sha256:9e40b024480c35d5c67114528ff28a87ff96add636bfdf9801099f581f53157e
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot"
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+          # Exercises 5 workbench image flavors in one file.
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
+            prepull_images: >-
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cuda-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
@@ -68,10 +106,15 @@ jobs:
           # whole file) so each can carry its own prepull_images/extra_robot_args. Both share
           # this file's Suite Setup/Teardown, so each entry re-runs that (~1-2min extra, ok).
           #
-          # Test A (Sanity, single image) already passes reliably - no pre-pull needed.
+          # Test A (Sanity, single image) already passes reliably, but pre-pull anyway since
+          # it's free and keeps this entry consistent with the rest of the matrix.
           - test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
             artifact_suffix: "sanity"
             extra_robot_args: "-i Sanity"
+            prepull_images: >-
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-datascience-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
           # Test B (Tier1, templated over PyTorch/TensorFlow/TrustyAI images): fails because
           # the TrustyAI image's cold pull can take ~5 minutes under CI I/O load, blowing the
           # robot test's fixed 5-minute workbench-spawn timeout. See
@@ -118,6 +161,7 @@ jobs:
 
           # my env does make everyone cluster-admin, so perms tests are meaningless
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
+            prepull_images: quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
           # TODO: 9) error: the server doesn't have a resource type "group": 1 != 0
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot"
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -223,13 +223,27 @@ jobs:
       - name: Wait for istio image-puller DaemonSet to be ready
         run: kubectl rollout status daemonset/image-puller-istio -n kube-system --timeout=600s
 
+      - name: Deploy stuff into Kubernetes
+        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
+        env:
+          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
+
       # Same in-cluster image-puller mechanism as above, for images a matrix entry declares via
       # `prepull_images` (large workbench/runtime images that can otherwise cold-pull slowly
       # enough under CI I/O load to blow a robot test's fixed spawn timeout - see issue #67).
       # No-op for entries without prepull_images. Only creates the DaemonSet here - the
       # blocking wait for it happens later, right before "Run ods-ci tests", so the pull runs
-      # in the background, overlapping with the rest of this job's setup (deploy.py, Poetry,
-      # oc login) instead of costing extra wall-clock time on top of it.
+      # in the background, overlapping with the rest of this job's setup (Poetry, oc login)
+      # instead of costing extra wall-clock time on top of it.
+      #
+      # Deliberately placed *after* "Deploy stuff into Kubernetes", not before it like the
+      # istio pre-pull: cert-manager/ArgoCD/Kyverno's own image pulls are on deploy.py's
+      # critical path (it blocks on their readiness), and this DaemonSet's ~35GB of large
+      # images pulling concurrently starved those small, normally-instant pulls badly enough
+      # that deploy.py's `kubectl wait ... cert-manager` timed out after 5 minutes with the
+      # images still stuck in ContainerCreating - see PR #72 CI run 32532246937. Kubernetes
+      # has no pull-priority mechanism that would let this stay ahead of that queue and not
+      # matter; not competing with deploy.py's own pulls at all is simpler and sufficient.
       - name: Pre-pull matrix-specified images via image-puller DaemonSet
         if: matrix.prepull_images
         run: |
@@ -264,11 +278,6 @@ jobs:
                   - operator: Exists
                 containers:${containers}
           EOF
-
-      - name: Deploy stuff into Kubernetes
-        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
-        env:
-          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
 
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -307,13 +307,33 @@ jobs:
       - name: Prepare test-variables.yml
         run: mv components/ods-ci/test-variables.yml ods-ci/ods_ci/test-variables.yml
 
-      # The DaemonSet was created way back before "Deploy stuff into Kubernetes"; by now it's
-      # had the whole deploy/Poetry/oc-login setup's worth of wall-clock time to pull in the
+      # The DaemonSet was created right after "Deploy stuff into Kubernetes"; by now it's had
+      # the Poetry/oc-login/test-variables setup's worth of wall-clock time to pull in the
       # background, so this should return near-instantly. This is the actual guarantee that
       # the images are cached before the robot test below tries to spawn a workbench with one.
+      #
+      # `kubectl rollout status` only reports pod-count-level state (how many nodes have the
+      # pod, how many are Available) - with one node and one pod holding all N images as
+      # sibling containers, that flips straight from 0 to 1 the moment every container is
+      # Ready, so on its own this step would print nothing for the entire wait and then either
+      # succeed or time out with zero indication of which image was slow. Stream the pod's own
+      # events (Pulling/Pulled per container) in the background for actual visibility.
       - name: Wait for matrix-specified image-puller DaemonSet to be ready
         if: matrix.prepull_images
-        run: kubectl rollout status daemonset/image-puller-prepull -n kube-system --timeout=600s
+        run: |
+          set -Eeuxo pipefail
+          pod=""
+          for _ in $(seq 1 30); do
+            pod="$(kubectl get pods -n kube-system -l app=image-puller-prepull -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+            [ -n "$pod" ] && break
+            sleep 1
+          done
+          if [ -n "$pod" ]; then
+            kubectl get events -n kube-system --field-selector "involvedObject.name=${pod}" --watch &
+            watch_pid=$!
+            trap 'kill "$watch_pid" 2>/dev/null || true' EXIT
+          fi
+          kubectl rollout status daemonset/image-puller-prepull -n kube-system --timeout=600s
 
       # NOTE: Tests in ods-ci often depend on what's before them in the file, so it's best to run file-by-file
       - name: Run ods-ci tests

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -248,6 +248,11 @@ jobs:
       # images still stuck in ContainerCreating - see PR #72 CI run 32532246937. Kubernetes
       # has no pull-priority mechanism that would let this stay ahead of that queue and not
       # matter; not competing with deploy.py's own pulls at all is simpler and sufficient.
+      # One DaemonSet per image, not one DaemonSet with N sibling containers: kubelet's pod
+      # worker starts a single pod's own containers sequentially regardless of the node's
+      # maxParallelImagePulls setting (see components/00-kind-cluster.yaml) - that setting only
+      # allows concurrency *across* pods. Separate pods actually let up to 3 of these pulls run
+      # at once instead of strictly one-at-a-time.
       - name: Pre-pull matrix-specified images via image-puller DaemonSet
         if: matrix.prepull_images
         shell: python {0}
@@ -258,30 +263,28 @@ jobs:
           import subprocess
 
           images = os.environ["PREPULL_IMAGES"].split()
-          containers = [
-              {"name": f"img-{i}", "image": image, "command": ["sleep", "720h"]}
-              for i, image in enumerate(images)
-          ]
-          manifest = {
-              "apiVersion": "apps/v1",
-              "kind": "DaemonSet",
-              "metadata": {
-                  "name": "image-puller-prepull",
-                  "namespace": "kube-system",
-                  "labels": {"app": "image-puller-prepull"},
-              },
-              "spec": {
-                  "selector": {"matchLabels": {"app": "image-puller-prepull"}},
-                  "template": {
-                      "metadata": {"labels": {"app": "image-puller-prepull"}},
-                      "spec": {
-                          "tolerations": [{"operator": "Exists"}],
-                          "containers": containers,
+          for i, image in enumerate(images):
+              name = f"image-puller-prepull-{i}"
+              manifest = {
+                  "apiVersion": "apps/v1",
+                  "kind": "DaemonSet",
+                  "metadata": {
+                      "name": name,
+                      "namespace": "kube-system",
+                      "labels": {"app": name},
+                  },
+                  "spec": {
+                      "selector": {"matchLabels": {"app": name}},
+                      "template": {
+                          "metadata": {"labels": {"app": name}},
+                          "spec": {
+                              "tolerations": [{"operator": "Exists"}],
+                              "containers": [{"name": "img", "image": image, "command": ["sleep", "720h"]}],
+                          },
                       },
                   },
-              },
-          }
-          subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
+              }
+              subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
         env:
           PREPULL_IMAGES: ${{ matrix.prepull_images }}
 
@@ -313,51 +316,41 @@ jobs:
       - name: Prepare test-variables.yml
         run: mv components/ods-ci/test-variables.yml ods-ci/ods_ci/test-variables.yml
 
-      # The DaemonSet was created right after "Deploy stuff into Kubernetes"; by now it's had
-      # the Poetry/oc-login/test-variables setup's worth of wall-clock time to pull in the
-      # background, so this should return near-instantly. This is the actual guarantee that
-      # the images are cached before the robot test below tries to spawn a workbench with one.
+      # The DaemonSets were created right after "Deploy stuff into Kubernetes"; by now they've
+      # had the Poetry/oc-login/test-variables setup's worth of wall-clock time to pull in the
+      # background, so this should return quickly. This is the actual guarantee that the
+      # images are cached before the robot test below tries to spawn a workbench with one.
       #
       # `kubectl rollout status` only reports pod-count-level state (how many nodes have the
-      # pod, how many are Available) - with one node and one pod holding all N images as
-      # sibling containers, that flips straight from 0 to 1 the moment every container is
-      # Ready, so on its own this step would print nothing for the entire wait and then either
-      # succeed or time out with zero indication of which image was slow. Stream the pod's own
-      # events (Pulling/Pulled per container) in the background for actual visibility.
+      # pod, how many are Available) - it wouldn't otherwise print anything for the whole wait.
+      # Stream kube-system's events (Pulling/Pulled per pod) in the background for visibility,
+      # and print elapsed time to compare against the old single-pod/sequential-containers
+      # approach.
       - name: Wait for matrix-specified image-puller DaemonSet to be ready
         if: matrix.prepull_images
         shell: python {0}
         # language: python
         run: |
+          import os
           import subprocess
           import time
 
-          pod = ""
-          for _ in range(30):
-              result = subprocess.run(
-                  ["kubectl", "get", "pods", "-n", "kube-system", "-l", "app=image-puller-prepull",
-                   "-o", "jsonpath={.items[0].metadata.name}"],
-                  capture_output=True, text=True,
-              )
-              pod = result.stdout.strip()
-              if pod:
-                  break
-              time.sleep(1)
+          images = os.environ["PREPULL_IMAGES"].split()
+          names = [f"image-puller-prepull-{i}" for i in range(len(images))]
 
-          watcher = None
-          if pod:
-              watcher = subprocess.Popen([
-                  "kubectl", "get", "events", "-n", "kube-system",
-                  f"--field-selector=involvedObject.name={pod}", "--watch",
-              ])
+          watcher = subprocess.Popen(["kubectl", "get", "events", "-n", "kube-system", "--watch"])
+          start = time.time()
           try:
-              subprocess.run([
-                  "kubectl", "rollout", "status", "daemonset/image-puller-prepull",
-                  "-n", "kube-system", "--timeout=600s",
-              ], check=True)
+              for name in names:
+                  subprocess.run(
+                      ["kubectl", "rollout", "status", f"daemonset/{name}", "-n", "kube-system", "--timeout=600s"],
+                      check=True,
+                  )
+              print(f"all {len(names)} image-puller DaemonSets ready after {time.time() - start:.1f}s")
           finally:
-              if watcher:
-                  watcher.terminate()
+              watcher.terminate()
+        env:
+          PREPULL_IMAGES: ${{ matrix.prepull_images }}
 
       # NOTE: Tests in ods-ci often depend on what's before them in the file, so it's best to run file-by-file
       - name: Run ods-ci tests

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -13,34 +13,53 @@ permissions: {}
 
 jobs:
   rhoai-in-kind:
+    name: >-
+      rhoai-in-kind (${{ matrix.workbench_branch }}, ${{ matrix.test_case }}${{ matrix.artifact_suffix && format(' [{0}]', matrix.artifact_suffix) || '' }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     strategy:
       fail-fast: false
+      # Every entry is a self-contained job spec (workbench_branch + test_case + optional
+      # extra_robot_args/prepull_images/artifact_suffix) rather than a flat `test_case:` axis,
+      # so that two entries can share the same test_case (see the split elyra entries below)
+      # without relying on GitHub Actions' include/axis merge semantics, which only merge an
+      # include entry into a generated combination when its keys match *all* axes - ambiguous
+      # and easy to get wrong once entries need heterogeneous optional fields.
       matrix:
-        workbench_branch:
-          - v1.36.0
+        include:
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
 
-        test_case:
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot"
-
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-image-tags.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-folder-permissions.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot"
           # TODO: Executing keyword 'Login To Openshift' failed
@@ -52,10 +71,40 @@ jobs:
           #- "tests/Tests/0500__ide/0507__culler/culler.robot"
 
           # oc new-project "elyra-test-6893" --display-name="elyra-test-6893" --description="testing Elyra pipeline functionality" --as=ldap-user2 --as-group=system:authenticated --as-group=system:authenticated:oauth 2>&1
-          - "tests/Tests/0500__ide/0502__ide_elyra.robot"
+          #
+          # Split into one matrix entry per robot Test Case (rather than one entry for the
+          # whole file) so each can carry its own prepull_images/extra_robot_args. Both share
+          # this file's Suite Setup/Teardown, so each entry re-runs that (~1-2min extra, ok).
+          #
+          # Test A (Sanity, single image) already passes reliably - no pre-pull needed.
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
+            artifact_suffix: "sanity"
+            extra_robot_args: "-i Sanity"
+          # Test B (Tier1, templated over PyTorch/TensorFlow/TrustyAI images): fails because
+          # the TrustyAI image's cold pull can take ~5 minutes under CI I/O load, blowing the
+          # robot test's fixed 5-minute workbench-spawn timeout. See
+          # https://github.com/jiridanek/rhoai-in-kind/issues/67
+          # A DevSpaces-like DaemonSet image-puller (RHOAIENG-56335) was considered instead of
+          # this ad-hoc pre-pull and rejected: that mechanism only helps on multi-node
+          # autoscaling, where a racing puller pod and workload pod land on a new node
+          # together; this kind cluster is one static node that already exists before the test
+          # runs, so `kind load docker-image` (which injects the image directly, no pull at
+          # all) is simpler and strictly sufficient here.
+          # CAUTION: image tags are pinned to workbench_branch v1.36.0 above; keep in sync.
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
+            artifact_suffix: "tier1"
+            extra_robot_args: "-i Tier1"
+            prepull_images: >-
+              quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
 
           # my env does make everyone cluster-admin, so perms tests are meaningless
-          - "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
+          - workbench_branch: v1.36.0
+            test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"
           # TODO: 9) error: the server doesn't have a resource type "group": 1 != 0
           #- "tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot"
 
@@ -154,6 +203,20 @@ jobs:
           timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.25.1; do sleep 1; done'
           kind load docker-image docker.io/istio/pilot:1.25.1
 
+      # Pre-pulls large workbench/runtime images a matrix entry declares via `prepull_images`,
+      # straight into the kind node's containerd - avoids cold registry pulls racing a robot
+      # test's fixed spawn timeout under CI I/O load. No-op for entries without prepull_images.
+      - name: Pre-pull matrix-specified images inside kind cluster
+        if: matrix.prepull_images
+        run: |
+          set -Eeuxo pipefail
+          for image in ${{ matrix.prepull_images }}; do
+            # Observed worst case for a large workbench image under CI I/O load is ~5m0s
+            # (see issue #67); use a generous margin rather than cutting it close.
+            timeout 600s bash -c "while ! docker pull '$image'; do sleep 1; done"
+            kind load docker-image "$image"
+          done
+
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
       - name: Install Poetry
@@ -186,7 +249,7 @@ jobs:
       - name: Run ods-ci tests
         run: |
           set -Eeuxo pipefail
-          ./run_robot_test.sh --skip-oclogin true --test-variables-file ${{ github.workspace }}/ods-ci/ods_ci/test-variables.yml --test-case ${{ matrix.test_case }} --extra-robot-args '-e AutomationBug -e ProductBug -e Dashboard -e deprecatedTest -e ExcludeOnRHOAI -e Resources-GPU'
+          ./run_robot_test.sh --skip-oclogin true --test-variables-file ${{ github.workspace }}/ods-ci/ods_ci/test-variables.yml --test-case ${{ matrix.test_case }} --extra-robot-args '-e AutomationBug -e ProductBug -e Dashboard -e deprecatedTest -e ExcludeOnRHOAI -e Resources-GPU ${{ matrix.extra_robot_args }}'
         # the location is important and it's not worth it to change it
         # * poetry looks for the lock file in what is the current directory or its parents
         # * by default TEST_CASE_FILE=tests/Tests
@@ -209,13 +272,17 @@ jobs:
           import pathlib
           import os
           import re
-          
+
           test_case = os.environ["TEST_CASE"]
+          artifact_suffix = os.environ.get("ARTIFACT_SUFFIX", "")
           artifact_name = re.sub(r'^.*/(?P<filename>[^/]+)\.robot$', r'\g<filename>', test_case)
+          if artifact_suffix:
+              artifact_name = f"{artifact_name}-{artifact_suffix}"
           pathlib.Path(os.environ["GITHUB_OUTPUT"]).write_text(f"artifact-name={artifact_name}")
 
         env:
           TEST_CASE: ${{ matrix.test_case }}
+          ARTIFACT_SUFFIX: ${{ matrix.artifact_suffix }}
 
       - name: Collect logs
         run: ${PYTHON3} components/logs.py

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -193,32 +193,36 @@ jobs:
       # finished waiting (or already failed).
       # CAUTION: the image tag is likely to go out of date, try to keep in sync
       - name: Pre-pull istio image via image-puller DaemonSet
+        shell: python {0}
+        # language: python
         run: |
-          set -Eeuxo pipefail
-          cat <<EOF | kubectl apply -f -
-          apiVersion: apps/v1
-          kind: DaemonSet
-          metadata:
-            name: image-puller-istio
-            namespace: kube-system
-            labels:
-              app: image-puller-istio
-          spec:
-            selector:
-              matchLabels:
-                app: image-puller-istio
-            template:
-              metadata:
-                labels:
-                  app: image-puller-istio
-              spec:
-                tolerations:
-                  - operator: Exists
-                containers:
-                  - name: istio-pilot
-                    image: docker.io/istio/pilot:1.25.1
-                    command: ["sleep", "720h"]
-          EOF
+          import json
+          import subprocess
+
+          manifest = {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                  "name": "image-puller-istio",
+                  "namespace": "kube-system",
+                  "labels": {"app": "image-puller-istio"},
+              },
+              "spec": {
+                  "selector": {"matchLabels": {"app": "image-puller-istio"}},
+                  "template": {
+                      "metadata": {"labels": {"app": "image-puller-istio"}},
+                      "spec": {
+                          "tolerations": [{"operator": "Exists"}],
+                          "containers": [{
+                              "name": "istio-pilot",
+                              "image": "docker.io/istio/pilot:1.25.1",
+                              "command": ["sleep", "720h"],
+                          }],
+                      },
+                  },
+              },
+          }
+          subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
 
       - name: Wait for istio image-puller DaemonSet to be ready
         run: kubectl rollout status daemonset/image-puller-istio -n kube-system --timeout=600s
@@ -246,38 +250,40 @@ jobs:
       # matter; not competing with deploy.py's own pulls at all is simpler and sufficient.
       - name: Pre-pull matrix-specified images via image-puller DaemonSet
         if: matrix.prepull_images
+        shell: python {0}
+        # language: python
         run: |
-          set -Eeuxo pipefail
-          containers=""
-          i=0
-          for image in ${{ matrix.prepull_images }}; do
-            containers="${containers}
-                  - name: img-${i}
-                    image: \"${image}\"
-                    command: [\"sleep\", \"720h\"]"
-            i=$((i + 1))
-          done
-          cat <<EOF | kubectl apply -f -
-          apiVersion: apps/v1
-          kind: DaemonSet
-          metadata:
-            name: image-puller-prepull
-            namespace: kube-system
-            labels:
-              app: image-puller-prepull
-          spec:
-            selector:
-              matchLabels:
-                app: image-puller-prepull
-            template:
-              metadata:
-                labels:
-                  app: image-puller-prepull
-              spec:
-                tolerations:
-                  - operator: Exists
-                containers:${containers}
-          EOF
+          import json
+          import os
+          import subprocess
+
+          images = os.environ["PREPULL_IMAGES"].split()
+          containers = [
+              {"name": f"img-{i}", "image": image, "command": ["sleep", "720h"]}
+              for i, image in enumerate(images)
+          ]
+          manifest = {
+              "apiVersion": "apps/v1",
+              "kind": "DaemonSet",
+              "metadata": {
+                  "name": "image-puller-prepull",
+                  "namespace": "kube-system",
+                  "labels": {"app": "image-puller-prepull"},
+              },
+              "spec": {
+                  "selector": {"matchLabels": {"app": "image-puller-prepull"}},
+                  "template": {
+                      "metadata": {"labels": {"app": "image-puller-prepull"}},
+                      "spec": {
+                          "tolerations": [{"operator": "Exists"}],
+                          "containers": containers,
+                      },
+                  },
+              },
+          }
+          subprocess.run(["kubectl", "apply", "-f", "-"], input=json.dumps(manifest), text=True, check=True)
+        env:
+          PREPULL_IMAGES: ${{ matrix.prepull_images }}
 
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
@@ -320,20 +326,38 @@ jobs:
       # events (Pulling/Pulled per container) in the background for actual visibility.
       - name: Wait for matrix-specified image-puller DaemonSet to be ready
         if: matrix.prepull_images
+        shell: python {0}
+        # language: python
         run: |
-          set -Eeuxo pipefail
-          pod=""
-          for _ in $(seq 1 30); do
-            pod="$(kubectl get pods -n kube-system -l app=image-puller-prepull -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
-            [ -n "$pod" ] && break
-            sleep 1
-          done
-          if [ -n "$pod" ]; then
-            kubectl get events -n kube-system --field-selector "involvedObject.name=${pod}" --watch &
-            watch_pid=$!
-            trap 'kill "$watch_pid" 2>/dev/null || true' EXIT
-          fi
-          kubectl rollout status daemonset/image-puller-prepull -n kube-system --timeout=600s
+          import subprocess
+          import time
+
+          pod = ""
+          for _ in range(30):
+              result = subprocess.run(
+                  ["kubectl", "get", "pods", "-n", "kube-system", "-l", "app=image-puller-prepull",
+                   "-o", "jsonpath={.items[0].metadata.name}"],
+                  capture_output=True, text=True,
+              )
+              pod = result.stdout.strip()
+              if pod:
+                  break
+              time.sleep(1)
+
+          watcher = None
+          if pod:
+              watcher = subprocess.Popen([
+                  "kubectl", "get", "events", "-n", "kube-system",
+                  f"--field-selector=involvedObject.name={pod}", "--watch",
+              ])
+          try:
+              subprocess.run([
+                  "kubectl", "rollout", "status", "daemonset/image-puller-prepull",
+                  "-n", "kube-system", "--timeout=600s",
+              ], check=True)
+          finally:
+              if watcher:
+                  watcher.terminate()
 
       # NOTE: Tests in ods-ci often depend on what's before them in the file, so it's best to run file-by-file
       - name: Run ods-ci tests

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -79,6 +79,23 @@ jobs:
           # image-puller DaemonSet steps below (see their comments for the RHOAIENG-56335 /
           # che-incubator/kubernetes-image-puller background).
           # CAUTION: image tags are pinned to the job's WORKBENCH_BRANCH env above; keep in sync.
+          #
+          # The DSPA (Data Science Pipelines Application) this test spins up is per-project and
+          # created fresh by the robot test's own Suite Setup ("Create Pipeline Server"), not by
+          # deploy.py, so its whole control-plane stack + DB backend also cold-pulls during the
+          # test run, on top of the 3 workbench images + runtime image above. Found by reading
+          # the actual pod specs (podss.yaml) in a passing run's cluster-logs artifact - none of
+          # this shows up in the job's own console log, since the pre-pull wait step's event
+          # watcher is scoped to kube-system, not the per-test elyra-test-NNNN namespace.
+          # These control-plane images are individually small (tens/hundreds of MB, single-digit
+          # seconds each) so they aren't a timeout risk the way the multi-GB workbench images
+          # are, but pre-pulling them is free and removes them from the Suite Setup critical path
+          # too. Digests are pinned by DSPO's own default image config (DSPO v2.15.1 per
+          # dspo-version-pin-baseline) - keep in sync if DSPO's version pin changes.
+          # (quay.io/jdanek/origin-oauth-proxy and quay.io/maistra/proxyv2-ubi8 are deliberately
+          # NOT listed: both consistently pull in <1s in every run checked, since they're already
+          # resident on the node from deploy.py's own bootstrap - other components use the same
+          # oauth-proxy/istio-sidecar images well before this test starts.)
           - test_case: "tests/Tests/0500__ide/0502__ide_elyra.robot"
             artifact_suffix: "tier1"
             extra_robot_args: "-i Tier1"
@@ -86,7 +103,18 @@ jobs:
               quay.io/opendatahub/odh-workbench-jupyter-pytorch-cuda-py312-ubi9:2025b-v1.36
               quay.io/opendatahub/odh-workbench-jupyter-tensorflow-cuda-py312-ubi9:2025b-v1.36
               quay.io/opendatahub/odh-workbench-jupyter-trustyai-cpu-py312-ubi9:2025b-v1.36
+              quay.io/opendatahub/odh-workbench-jupyter-minimal-cpu-py312-ubi9:2025b-v1.36
               quay.io/opendatahub/odh-pipeline-runtime-datascience-cpu-py312-ubi9:2025b-v1.36
+              quay.io/fedora/mariadb-103:latest
+              quay.io/opendatahub/ds-pipelines-api-server@sha256:b5b9d057d7551ac184a6491b393d32e2e3ac2a9696697e25a64429fc4f4ed046
+              quay.io/opendatahub/ds-pipelines-persistenceagent@sha256:4b8316a8878c0d36b8d2297ed9f273fb0e6ffe0433fa24e908686a6f0888f919
+              quay.io/opendatahub/ds-pipelines-scheduledworkflow@sha256:80be2933c89ab9639c2ad189dfaf7a0566e22487d08ad5983197e6d4433692ce
+              quay.io/opendatahub/ds-pipelines-argo-workflowcontroller@sha256:995f06328569b558d63cf727c0674df71b1927f74ab60e966596ccb8c06e12f8
+              quay.io/opendatahub/ds-pipelines-argo-argoexec@sha256:da1b0d502ae97160185ec5debc2f0c8d54f70b01be4ea4a9339d7137cc3918a9
+              quay.io/opendatahub/ds-pipelines-driver@sha256:4fefd903a775916632f3eb59706ecbea902b1961bcb1e20e142b06672cebfd61
+              quay.io/opendatahub/ds-pipelines-launcher@sha256:48b68a2e888722021721e6f4c60e6a76eedd530b11df796b32fe04c8b01636d5
+              quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:973ed0a2812215e0ed43817f70adf6a90ef808215186005c66d40b482eafc968
+              quay.io/opendatahub/mlmd-grpc-server@sha256:9e905b2de2fb6801716a14ebd6e589cac82fef26741825d06717d695a37ff199
 
           # my env does make everyone cluster-admin, so perms tests are meaningless
           - test_case: "tests/Tests/0500__ide/0501__ide_jupyterhub/base-user-shutdown-test.robot"

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -227,31 +227,27 @@ jobs:
       - name: Wait for istio image-puller DaemonSet to be ready
         run: kubectl rollout status daemonset/image-puller-istio -n kube-system --timeout=600s
 
-      - name: Deploy stuff into Kubernetes
-        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
-        env:
-          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
-
       # Same in-cluster image-puller mechanism as above, for images a matrix entry declares via
       # `prepull_images` (large workbench/runtime images that can otherwise cold-pull slowly
       # enough under CI I/O load to blow a robot test's fixed spawn timeout - see issue #67).
       # No-op for entries without prepull_images. Only creates the DaemonSet here - the
       # blocking wait for it happens later, right before "Run ods-ci tests", so the pull runs
-      # in the background, overlapping with the rest of this job's setup (Poetry, oc login)
-      # instead of costing extra wall-clock time on top of it.
+      # in the background, overlapping with the rest of this job's setup (deploy.py, Poetry,
+      # oc login) instead of costing extra wall-clock time on top of it.
       #
-      # Deliberately placed *after* "Deploy stuff into Kubernetes", not before it like the
-      # istio pre-pull: cert-manager/ArgoCD/Kyverno's own image pulls are on deploy.py's
-      # critical path (it blocks on their readiness), and this DaemonSet's ~35GB of large
-      # images pulling concurrently starved those small, normally-instant pulls badly enough
-      # that deploy.py's `kubectl wait ... cert-manager` timed out after 5 minutes with the
-      # images still stuck in ContainerCreating - see PR #72 CI run 32532246937. Kubernetes
-      # has no pull-priority mechanism that would let this stay ahead of that queue and not
-      # matter; not competing with deploy.py's own pulls at all is simpler and sufficient.
+      # Placed *before* "Deploy stuff into Kubernetes", same as the istio pre-pull above: this
+      # used to run after deploy.py instead, because with kubelet's default one-pull-at-a-time
+      # FIFO queue, this DaemonSet's ~35GB of large images pulling concurrently starved
+      # cert-manager/ArgoCD/Kyverno's own small, normally-instant pulls badly enough that
+      # deploy.py's `kubectl wait ... cert-manager` timed out after 5 minutes - see PR #72 CI
+      # run 32532246937. Now that components/00-kind-cluster.yaml sets
+      # maxParallelImagePulls: 6, deploy.py's small pulls can get a concurrent slot instead of
+      # queuing strictly behind these, so pre-pulling can start immediately and overlap with
+      # deploy.py's own runtime too.
       # One DaemonSet per image, not one DaemonSet with N sibling containers: kubelet's pod
       # worker starts a single pod's own containers sequentially regardless of the node's
       # maxParallelImagePulls setting (see components/00-kind-cluster.yaml) - that setting only
-      # allows concurrency *across* pods. Separate pods actually let up to 3 of these pulls run
+      # allows concurrency *across* pods. Separate pods actually let multiple of these pulls run
       # at once instead of strictly one-at-a-time.
       - name: Pre-pull matrix-specified images via image-puller DaemonSet
         if: matrix.prepull_images
@@ -288,6 +284,11 @@ jobs:
         env:
           PREPULL_IMAGES: ${{ matrix.prepull_images }}
 
+      - name: Deploy stuff into Kubernetes
+        run: ${PYTHON3} components/deploy.py --workbench-branch=${{ env.WORKBENCH_BRANCH }}
+        env:
+          PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
+
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
       - name: Install Poetry
@@ -316,10 +317,11 @@ jobs:
       - name: Prepare test-variables.yml
         run: mv components/ods-ci/test-variables.yml ods-ci/ods_ci/test-variables.yml
 
-      # The DaemonSets were created right after "Deploy stuff into Kubernetes"; by now they've
-      # had the Poetry/oc-login/test-variables setup's worth of wall-clock time to pull in the
-      # background, so this should return quickly. This is the actual guarantee that the
-      # images are cached before the robot test below tries to spawn a workbench with one.
+      # The DaemonSets were created right before "Deploy stuff into Kubernetes"; by now they've
+      # had deploy.py's own runtime plus the Poetry/oc-login/test-variables setup's worth of
+      # wall-clock time to pull in the background, so this should return quickly. This is the
+      # actual guarantee that the images are cached before the robot test below tries to spawn
+      # a workbench with one.
       #
       # `kubectl rollout status` only reports pod-count-level state (how many nodes have the
       # pod, how many are Available) - it wouldn't otherwise print anything for the whole wait.

--- a/components/00-kind-cluster.yaml
+++ b/components/00-kind-cluster.yaml
@@ -17,7 +17,7 @@ nodes:
       - |
         kind: KubeletConfiguration
         serializeImagePulls: false
-        maxParallelImagePulls: 3
+        maxParallelImagePulls: 6
     extraPortMappings:
       - containerPort: 30207
         hostPort: 15021

--- a/components/00-kind-cluster.yaml
+++ b/components/00-kind-cluster.yaml
@@ -6,6 +6,18 @@ networking:
   apiServerPort: 6443
 nodes:
   - role: control-plane
+    # Default kubelet behavior is serializeImagePulls: true (one image pull at a time,
+    # node-wide, FIFO across every pod) - kind doesn't override this either. That queue isn't
+    # priority-aware, so a background image-puller DaemonSet's large pulls queued ahead of
+    # something else's small, normally-instant pull can starve it for the whole duration
+    # rather than actually contending for bandwidth (see .github/workflows's image-puller
+    # DaemonSet steps and the cert-manager starvation they caused before being reordered).
+    # Allow a few pulls in parallel so unrelated small pulls aren't stuck behind one big queue.
+    kubeadmConfigPatches:
+      - |
+        kind: KubeletConfiguration
+        serializeImagePulls: false
+        maxParallelImagePulls: 3
     extraPortMappings:
       - containerPort: 30207
         hostPort: 15021


### PR DESCRIPTION
## Summary

Splits `tests/Tests/0500__ide/0502__ide_elyra.robot`'s two Robot Framework test cases into
separate CI matrix jobs (`sanity`, `tier1`) so each can carry its own optional
`prepull_images`/`extra_robot_args`, then designs and iteratively hardens an in-cluster
DaemonSet-based image pre-pull mechanism to fix the TrustyAI workbench's cold-pull timeout
(#67) — eventually extending pre-pull to every other matrix job's own workbench/runtime images
once the mechanism proved reliable.

## Root cause

TrustyAI (and other large, multi-GB workbench/runtime) images can take several minutes to
cold-pull under CI runner I/O load — longer than the robot test's fixed workbench-spawn
timeout, failing the test for reasons unrelated to the feature under test. Fixed by pre-pulling
images into the kind node *before* the robot test needs them, via an in-cluster DaemonSet
mechanism (not `kind load docker-image`, which turned out to be even slower than a plain
registry pull and eventually failed outright under disk pressure — see Trajectory). The
pre-pull mechanism itself went through several designs before landing on one that's both fast
and doesn't risk starving `deploy.py`'s own image pulls — two separate starvation failure
modes were found and fixed along the way (see Trajectory).

## Related issue

Mitigates #67.

## Test plan

- [x] Verified the `include:`-only matrix conversion produces the expected job count/display
      names (no accidental job merging/collision from GitHub Actions' include+axis semantics)
- [x] Verified the elyra sanity/tier1 split produces unique `upload-artifact` names (no
      collision from both entries sharing the same underlying `.robot` file)
- [x] All 17 matrix entries' `prepull_images` lists were derived from actual `podss.yaml`/
      `eventss.yaml` in cluster-logs artifacts of full CI runs, not guessed from test source —
      cross-checked across multiple independent runs for stability
- [x] Multiple full 18-job CI runs plus targeted `gh run rerun --job` benchmark loops (full
      timing tables in `pulling_timings.md`, kept locally/untracked as a working investigation
      doc) confirm: (a) zero new regressions vs. the pre-change baseline — the same 4
      pre-existing, unrelated jobs fail identically before and after every change in this PR;
      (b) the final two-phase pre-pull design keeps `deploy.py` near its undisturbed baseline
      duration (~250-280s) across 5 consecutive samples, with no repeat of either starvation
      failure mode that earlier designs hit
- [ ] CI (this PR's own checks)

<details>
<summary>Plan</summary>

Original approved plan (since substantially extended through implementation - see Trajectory
for what changed and why):

Split the single "elyra" matrix entry (which today runs the whole `.robot` file containing 2
independent Robot Test Cases) into one matrix entry per Test Case, so each can carry two new
optional per-entry fields: a list of images to pre-pull, and extra robot CLI args to filter
which test in the file actually runs. Add `include:`-only matrix entries (not a flat
`test_case:` axis + `include:` overlay) to sidestep GitHub Actions' ambiguous include/axis merge
semantics when two entries need to share the same `test_case` value. Fix the artifact-name
collision this split introduces (both entries derive the same name from the shared filename) via
a new `artifact_suffix` field. Pre-pull the Tier1 entry's needed images (PyTorch, TensorFlow,
TrustyAI, datascience runtime) via `kind load docker-image` before the robot test runs, reusing
the retry-loop idiom already used for the istio pilot image pre-pull. Thread `extra_robot_args`
through to `run_robot_test.sh`'s existing `--extra-robot-args` passthrough. Give the split
entries a distinct job display name via a `name:` override using `artifact_suffix`.

Research conclusion at plan time on whether to use a more "robust" DevSpaces-like DaemonSet
image-puller instead of `kind load docker-image`: **no, `kind load` is sufficient** — the
DaemonSet approach (`che-incubator/kubernetes-image-puller`, RHOAIENG-56335) only helps on
multi-node autoscaling, where a racing image-puller pod and workload pod land on a new node
together; this kind cluster is one static node that already exists before the test runs, so
`kind load` should be strictly sufficient. **This conclusion was later proven wrong in
practice** (see Trajectory) — `kind load` itself turned out to be the slower, less reliable
mechanism, and the PR ended up building the DaemonSet approach after all.

</details>

<details>
<summary>Trajectory</summary>

**Phase 1 — matrix split + `kind load`-based pre-pull (original plan, commits `dd31a40`,
`fbedda2`):**

1. Investigated a failing elyra CI run and found the templated Tier1 test's TrustyAI workbench
   image (~6GB) sometimes takes ~5 minutes to cold-pull under CI I/O load, exceeding the robot
   test's fixed 5-minute workbench-spawn timeout (baseline evidence from a live CI run: pull
   times datascience 34.5s/1.8GB, pytorch 2m20s/10GB, tensorflow 1m43s/9.3GB, trustyai
   anomalously slow at 5m0.4s/6GB).
2. Confirmed the file's second Robot Test Case is templated over 3 workbench images and runs
   independently of the first (Sanity) test case, both currently forced into one matrix entry.
3. Designed and implemented the `include:`-only matrix split (one entry per Test Case, new
   `artifact_suffix`/`extra_robot_args`/`prepull_images` fields), the artifact-name-collision
   fix, the `extra_robot_args` passthrough, and a `kind load docker-image` pre-pull step for the
   Tier1 entry's 4 images, guarded by `if: matrix.prepull_images` truthiness so it's a no-op for
   every other entry.
4. Pulled `workbench_branch` out of the per-entry matrix into a job-level `env:
   WORKBENCH_BRANCH` (user request: it never actually varies between entries, no reason to
   repeat it ~18 times) — required removing it from the job's `name:` expression too, since
   GitHub Actions doesn't expose the `env` context to `jobs.<job_id>.name` (a restriction
   discovered the hard way via a CI validation failure, fixed in `a593faa`).

**Phase 2 — `kind load` turns out to be the wrong call; replaced with an in-cluster DaemonSet
(commits `ad5aa43`, `ad5b717`, `c15c4c7`, `40f5a45`, `714a9ac`, `0aa873d`):**

5. The first CI run under the new pre-pull step still failed: `kind load docker-image` (which
   internally does `docker save` piped into the kind node container) took far longer than the
   registry pull itself — 7m14s just for the PyTorch image's `kind load`, on top of its own
   ~2m45s `docker pull` — and eventually failed outright with a `docker save` I/O error,
   consistent with the runner's disk filling up from storing the same image twice (once on the
   GHA runner's host Docker daemon, once duplicated into the kind node's containerd). This
   directly falsified the plan's research conclusion that `kind load` would be sufficient.
6. Replaced the mechanism with an in-cluster DaemonSet approach after all — the same
   `che-incubator/kubernetes-image-puller` pattern the original plan had considered and set
   aside: each container runs `sleep 720h` on the target image, so containerd pulls it directly
   (no host-side double-pull) and a real running container keeps kubelet's image GC from
   evicting it. Reused this same pattern for the pre-existing istio pilot image pre-pull too.
7. First DaemonSet placement was *before* `deploy.py` (matching istio's pre-pull position) —
   this caused a **first starvation failure**: the DaemonSet's ~35GB of large image pulls
   monopolized kubelet's default `serializeImagePulls: true` FIFO queue, starving
   cert-manager's own tiny, normally-instant pulls badly enough that `deploy.py`'s 5-minute
   `kubectl wait ... cert-manager` timed out. Fixed by moving DaemonSet creation to *after*
   `deploy.py` instead (the blocking wait for it still deferred to just before the robot test
   runs, so pulling still overlaps with Poetry/oc-login/test-variables setup).
8. User asked whether the DaemonSet could be deprioritized instead of reordered; explored
   `PriorityClass` and initContainer-based serialization, but initContainers exit after running
   and lose kubelet's GC protection (user caught this), so simple reordering was kept as the
   fix.
9. Added visibility: streamed `kubectl get events -n kube-system --watch` in the background
   during the wait step, printing elapsed time, after the user asked for progress output beyond
   `kubectl rollout status`'s silent pod-count reporting.
10. Converted the bash-based pre-pull/wait steps to `shell: python {0}` (existing repo
    convention for building k8s manifests as Python dicts + `json.dumps()`) per user request.

**Phase 3 — discovering kind's kubelet pull concurrency, and single-pod vs. per-image
DaemonSets (commits `1a5b52e`, `0aa873d`, plus `components/00-kind-cluster.yaml`):**

11. Investigated kind's/kubelet's image-pull parallelism defaults; confirmed via
    `kubernetes/kubernetes` release-1.31 source that `serializeImagePulls` defaults to `true`
    and `maxParallelImagePulls` defaults to `nil` (mutually exclusive). Added a
    `kubeadmConfigPatches` `KubeletConfiguration` override in `components/00-kind-cluster.yaml`
    setting `serializeImagePulls: false` / `maxParallelImagePulls: 3` to allow concurrent pulls.
12. First CI run under this setting showed only **one** `Pulling` event at a time despite the
    new setting — root-caused to kubelet's pod worker starting a single pod's own containers
    strictly sequentially, *regardless* of `maxParallelImagePulls` (that setting only governs
    concurrency *across* pods). The single-DaemonSet-with-N-sibling-containers shape used since
    Phase 2 made the new concurrency setting a no-op.
13. Split into **one DaemonSet per image** instead (N separate single-container DaemonSets) so
    `maxParallelImagePulls` could actually apply across pods. Confirmed via the event stream:
    3 of 4 images started pulling within the same second, with the 4th visibly queuing and
    starting only once one of the first 3 finished — first hard confirmation the setting works,
    just not with one pod per N containers.

**Phase 4 — discovering the tier1 image list was incomplete; expanding pre-pull to every
matrix job (commits `2d0a963`, `824e8f6`):**

14. On request, read through actual CI logs to find every image the elyra tier1 test uses.
    Console logs alone were insufficient (the pre-pull wait step's event watcher is scoped to
    `kube-system`, never seeing the per-test `elyra-test-NNNN` namespace); had to download a
    passing run's `cluster-logs` artifact and read `podss.yaml`/`eventss.yaml` directly. Found
    that the per-project DSPA this test creates (via its own Suite Setup, not `deploy.py`) also
    cold-pulls its whole control-plane stack (`ds-pipelines-api-server`, `-persistenceagent`,
    `-scheduledworkflow`, `-argo-workflowcontroller`, `-argo-argoexec`, `-driver`, `-launcher`,
    `-runtime-generic`, `mlmd-grpc-server`), a `mariadb` DB backend (since this repo's earlier
    Kyverno fix forces `pipelineStore: database`), and the `workaround` Suite-Setup workbench's
    minimal image — none of which were being pre-pulled. Added all of them to tier1's list
    (later trimmed back down by the user to just the multi-GB images that actually carry
    timeout risk, once the two-phase design made even the smaller ones' contribution
    marginal).
15. Extended the same discovery method (bulk-downloading a full 18-job run's cluster-logs
    artifacts, grepping `eventss.yaml` for pull events) to every *other* matrix job, adding each
    its own `prepull_images` list. Two special cases: `multiple-image-tags.robot` specifically
    exercises the previous release's (n-1, py311) images, pinned by `@sha256` digest since
    that's how the notebooks repo itself pins n-1 (no moving tag to track); `custom-image.robot`
    imports a hardcoded BYON image unrelated to the `WORKBENCH_BRANCH` release train.
    Verified zero regressions by comparing a full run against the pre-change baseline and
    confirming the exact same 4 pre-existing, unrelated jobs fail in both.

**Phase 5 — `maxParallelImagePulls` bump, a second starvation failure, and the two-phase
redesign (commit `3498be5`):**

16. User asked to try `maxParallelImagePulls: 6` and move the per-image DaemonSet creation back
    to *before* `deploy.py` (to overlap pulling with more of the job, on the theory that with
    real parallelism now available, `deploy.py`'s small pulls could get a fair concurrent slot
    instead of queuing strictly behind the large ones).
17. Ran a 5-sample benchmark of this configuration (`gh run rerun --job` targeting just the
    tier1 job, 4 successes + 1 failure): successes averaged 1312s total, faster than every prior
    configuration — but the failure was a **second, different starvation failure**:
    `deploy.py`'s `kubectl wait ... argocd --timeout 180s` timed out because ArgoCD's own image
    pull didn't get admitted into kubelet's pull queue until ~4.5 minutes in, stuck behind a
    burst of 15 background pulls that all arrived first (a 1-in-5 measured failure rate).
18. Discussed several fixes: lowering `maxParallelImagePulls` back down (rejected — the
    background pods still arrive first regardless of slot count, so fewer slots only makes
    `deploy.py`'s wait *longer*, not safer); raising it further (untested, trades queue
    starvation for raw bandwidth contention); splitting `deploy.py` into two steps so its own
    pulls get a first-mover queue advantage (rejected as too invasive for the payoff).
19. Landed on a **two-phase design** instead: phase 1 is a single DaemonSet with one pod and N
    sibling containers (deliberately reusing the "wrong" shape from Phase 3, since kubelet's
    strictly-sequential per-pod container starts now work *for* this purpose) fired
    fire-and-forget before `deploy.py` with no wait step — it only ever occupies **one**
    `maxParallelImagePulls` admission slot no matter how many images are listed, so `deploy.py`'s
    own pulls always find a free slot. Phase 2 is the existing one-DaemonSet-per-image approach,
    now fired *after* `deploy.py` (safe once its readiness waits are done), with the existing
    blocking wait unchanged in position. Re-requesting an image phase 1 already pulled is a fast
    no-op (content-addressed image store).
20. Also parametrized the ~24 repeated `2025b-v1.36` tag literals across the matrix behind a new
    `env.NOTEBOOK_IMAGE_TAG`, substituted at runtime via a `TAG` placeholder in each
    `prepull_images` entry (GitHub Actions matrix values can't reference the `env` context
    directly).
21. Benchmarked the two-phase design across two separate pushes (5 total tier1-job samples: 1
    initial + 4 `gh run rerun --job` reruns on the first push, then after a rebase onto `main`
    and a force-push, 1 more initial + 2 more reruns): `deploy.py` consistently landed back near
    its undisturbed baseline duration (~250-282s, vs. 347-515s under the risky all-before
    design), with zero repeats of either starvation failure mode across all runs. The only
    failure seen was an unrelated, pre-existing Robot Framework flake ("Saving completed" text
    not appearing within a 5-second window), confirmed independent of pre-pull state (the
    pre-pull steps had already succeeded well before that failure occurred).

**Split off into separate, independent PRs along the way** (not part of this PR's diff):
- #73 (merged) — gave each of the 3 CI workflows a short top-level `name:` for easier scanning,
  requested and implemented as a standalone change off `main`.
- #74 (open) — fixed all 3 workflows' istio pre-pull steps hardcoding
  `docker.io/istio/pilot:1.25.1` while `components/deploy.py`'s actual `ISTIO_VERSION` had moved
  to `1.26.2`, found incidentally while reviewing this PR's workflow file.

Full per-run timing tables, the specific failure logs/error messages for every diagnosed
failure, and the exact benchmark methodology are in `pulling_timings.md` (kept as a local,
untracked working document rather than committed repo documentation).

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution with faster environment preparation and more reliable readiness monitoring.
  * Expanded test coverage for Elyra scenarios, including dedicated sanity and Tier 1 validation.
  * Test results and artifacts are now organized more clearly for easier review and troubleshooting.

* **Chores**
  * Improved local test-cluster performance by enabling parallel image downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->