### PR TITLE
ci: give each workflow a short top-level name

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -1,3 +1,5 @@
+name: cypress
+
 on:
   pull_request:
   # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -1,3 +1,5 @@
+name: odh-tests
+
 on:
   pull_request:
   # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -1,3 +1,5 @@
+name: ods-ci
+
 on:
   pull_request:
   # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46


### PR DESCRIPTION
## Summary

All three GitHub Actions workflows in this repo use the same job id (`rhoai-in-kind`), and only one of them sets an explicit job `name:`, so in the Actions tab / PR checks list they're only distinguishable by long, matrix-derived job names rather than by which workflow they belong to. This adds a short, consistent top-level `name:` to each workflow file instead.

## Test plan

- [x] Validated all three files with `yq eval` and `actionlint` - only pre-existing, unrelated findings remain (a shellcheck style nit in ods-ci, an artifact-name type-inference gap in odh-tests-shiftleft), confirmed via `git diff --stat` to be outside this change's 2-line-per-file diff.
- [ ] CI (this PR triggers all three workflows; confirm each new name shows correctly in the checks list)

<details>
<summary>Plan</summary>

Requested directly in conversation: add a brief top-level `name:` to each of the three workflow files so they're easier to tell apart when scanning the Actions tab / PR checks list. Names suggested first, then confirmed/adjusted by the user before implementing:

- `rhoai-in-kind-with-ods-ci.yaml` -> `ods-ci`
- `rhoai-in-kind-with-cypress.yaml` -> `cypress`
- `rhoai-in-kind-with-odh-tests-shiftleft.yaml` -> `odh-tests` (user corrected my initial "Shiftleft" suggestion, and asked for consistent capitalization across all three)

</details>

<details>
<summary>Trajectory</summary>

1. User asked to give each workflow a brief name for easier scanning, and asked me to suggest naming first before implementing.
2. Checked `.github/workflows/` - confirmed all three workflows share the job id `rhoai-in-kind`, and only `rhoai-in-kind-with-ods-ci.yaml` has an explicit (long, matrix-derived) job `name:`; the other two have no job name override at all. This confirmed the actual scanning problem: nothing in the Actions UI currently distinguishes which of the three workflows a given check belongs to.
3. Proposed initial names: `ODS-CI`, `Cypress`, `Shiftleft` (dropping the redundant `rhoai-in-kind-with-` prefix from each, since the repo context already implies it).
4. User corrected: `Shiftleft` should be `odh-tests` instead (matching what that workflow actually runs - the opendatahub-tests suite), and asked for consistent capitalization across all three names.
5. Finalized on lowercase kebab-case for all three, matching the actual tool/project names: `ods-ci`, `cypress`, `odh-tests`.
6. Created a new branch (`jd-workflow-names`) off `origin/main`, independent of other in-progress work on a different branch, per the user's request to do this "in new pr".
7. Added `name: ods-ci` / `name: cypress` / `name: odh-tests` as the first line of each respective workflow file, before the existing `on:` block.
8. Validated all three files with `yq eval '.'` (YAML syntax) and `actionlint` (GitHub Actions semantics) - both passed with only pre-existing, unrelated findings (confirmed unrelated via `git diff --stat` showing exactly 2 lines added per file).
9. Committed and pushed.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added clear names to three automated validation workflows, making them easier to identify in CI results and workflow lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->