### PR TITLE
ci: fix istio pre-pull version drift (1.25.1 -> 1.26.2)

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -79,12 +79,15 @@ jobs:
       # ✘ Istiod encountered an error: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
       #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")Error: failed to install manifests: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
       #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")
-      # CAUTION: the image tag is likely to go out of date, try to keep in sync
+      # CAUTION: must match ISTIO_VERSION in components/deploy.py - it drifted to 1.25.1 here
+      # while deploy.py had already moved to 1.26.2, silently making this pre-pull a no-op for
+      # the version istiod actually needs. No automated check ties these together; if this ever
+      # drifts again, `istioctl install` will still work, just without the pre-pull benefit.
       - name: Pre-pull istio inside kind cluster
         run: |
           set -Eeuxo pipefail
-          timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.25.1; do sleep 1; done'
-          kind load docker-image docker.io/istio/pilot:1.25.1
+          timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.26.2; do sleep 1; done'
+          kind load docker-image docker.io/istio/pilot:1.26.2
 
       - name: Deploy stuff into Kubernetes
         run: ${PYTHON3} components/deploy.py --workbench-branch=${{ matrix.workbench_branch }}

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -60,12 +60,15 @@ jobs:
       # ✘ Istiod encountered an error: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
       #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")Error: failed to install manifests: failed to wait for resource: resources not ready after 5m0s: context deadline exceeded
       #    Deployment/istio-system/istiod (container failed to start: ImagePullBackOff: Back-off pulling image "docker.io/istio/pilot:1.25.1")
-      # CAUTION: the image tag is likely to go out of date, try to keep in sync
+      # CAUTION: must match ISTIO_VERSION in components/deploy.py - it drifted to 1.25.1 here
+      # while deploy.py had already moved to 1.26.2, silently making this pre-pull a no-op for
+      # the version istiod actually needs. No automated check ties these together; if this ever
+      # drifts again, `istioctl install` will still work, just without the pre-pull benefit.
       - name: Pre-pull istio inside kind cluster
         run: |
           set -Eeuxo pipefail
-          timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.25.1; do sleep 1; done'
-          kind load docker-image docker.io/istio/pilot:1.25.1
+          timeout 120s bash -c 'while ! docker pull docker.io/istio/pilot:1.26.2; do sleep 1; done'
+          kind load docker-image docker.io/istio/pilot:1.26.2
 
       - name: Deploy stuff into Kubernetes
         run: ${PYTHON3} components/deploy.py --workbench-branch=${{ matrix.workbench_branch }}

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -264,7 +264,10 @@ jobs:
       # placed after that one (as this used to be) cannot help the failure above at all: GitHub
       # Actions steps never overlap, so by the time a later step starts, istioctl has already
       # finished waiting (or already failed).
-      # CAUTION: the image tag is likely to go out of date, try to keep in sync
+      # CAUTION: must match ISTIO_VERSION in components/deploy.py - it drifted to 1.25.1 here
+      # while deploy.py had already moved to 1.26.2, silently making this pre-pull a no-op for
+      # the version istiod actually needs. No automated check ties these together; if this ever
+      # drifts again, `istioctl install` will still work, just without the pre-pull benefit.
       - name: Pre-pull istio image via image-puller DaemonSet
         shell: python {0}
         # language: python
@@ -288,7 +291,7 @@ jobs:
                           "tolerations": [{"operator": "Exists"}],
                           "containers": [{
                               "name": "istio-pilot",
-                              "image": "docker.io/istio/pilot:1.25.1",
+                              "image": "docker.io/istio/pilot:1.26.2",
                               "command": ["sleep", "720h"],
                           }],
                       },


### PR DESCRIPTION
## Summary

All three GitHub Actions workflows pre-pull `docker.io/istio/pilot:1.25.1` before installing istio, but `components/deploy.py`'s `ISTIO_VERSION` is actually `1.26.2`. The pre-pull was silently a no-op for the version istiod actually needs - it warmed an image that was never going to be requested, so it never sped up (or protected against) istiod's own cold pull the way it was meant to.

## Root cause

The two version references (`components/deploy.py`'s `ISTIO_VERSION` and each workflow's hardcoded pre-pull tag) aren't tied together by anything - no shared constant, no CI check. `deploy.py` moved to `1.26.2` at some point and the three workflows' pre-pull steps were never updated to match. Each pre-pull step already had a `CAUTION: the image tag is likely to go out of date, try to keep in sync` comment flagging this exact risk, but nothing enforced it.

## Test plan

- [x] Validated all three files with `yq eval` after resolving a stash-pop conflict against `main` (see trajectory) - confirmed final diffs are identical in shape across all three workflows.
- [x] Rebased onto `main` after PR #72 merged (which rewrote `ods-ci`'s istio pre-pull step from `docker pull`+`kind load` into a DaemonSet manifest) and re-resolved the resulting conflict; confirmed via `git diff origin/main` that the final diff correctly targets the new DaemonSet manifest's `"image": ...` field and leaves the other two workflows' `docker pull`/`kind load` diffs unchanged.
- [ ] CI (this PR triggers all three workflows; the istio pre-pull step itself has no functional gate, so success here mainly confirms the DaemonSet/`kind load` step and the subsequent `istioctl install` both still work with the corrected tag)

<details>
<summary>Plan</summary>

Requested directly in conversation, on the heels of unrelated pre-pull work on another branch: fix the wrong istio version hardcoded in all three workflows' pre-pull steps to match what `components/deploy.py` actually installs, as a standalone PR off `main` (independent of the other branch's still-in-progress, unmerged pre-pull redesign).

</details>

<details>
<summary>Trajectory</summary>

1. While reviewing a workflow file in the IDE, the user pointed out a prepull step referencing the wrong istio version - not what logs say.
2. Grepped `components/deploy.py` and found `ISTIO_VERSION = "1.26.2"`, then grepped all three workflow files and found every one hardcodes `docker.io/istio/pilot:1.25.1` in its pre-pull step (`ods-ci` via a DaemonSet manifest, `cypress` and `odh-tests-shiftleft` via `docker pull` + `kind load`) - confirming the drift.
3. Fixed the functional references in all three files on the currently-checked-out branch (`jd-force-dspa-pipelinestore-database`), deliberately leaving the historical `✘ Istiod encountered an error...` comment blocks untouched, since those are verbatim quotes of a real past incident at whatever version was in use then, not something to rewrite.
4. User asked not to push yet, then asked to make this a standalone PR off `main` instead - separate from the other branch's unrelated, still-unmerged pre-pull work.
5. Stashed the three modified files, checked out a new branch off `origin/main`, and popped the stash. `rhoai-in-kind-with-cypress.yaml` and `rhoai-in-kind-with-odh-tests-shiftleft.yaml` applied cleanly, but `rhoai-in-kind-with-ods-ci.yaml` conflicted: `main`'s copy of that file still uses the same old `docker pull`+`kind load` pre-pull shape as the other two workflows, since the DaemonSet-based rewrite is itself unmerged, still confined to the other branch - so the 3-way merge tried to reconcile two structurally divergent versions of the file.
6. Resolved by resetting that file to `main`'s actual (simple, `docker pull`+`kind load`) content and reapplying the same minimal version-bump fix by hand, matching the pattern already used for the other two workflows, rather than pulling in unrelated unmerged code via the stash.
7. Verified all three resulting diffs are structurally identical (same comment update, same two-line version bump) with `git diff`, then committed and pushed.
8. The other branch's PR (#72, the pre-pull redesign) merged to `main` shortly after, rewriting `ods-ci`'s istio pre-pull step into the DaemonSet-manifest shape this PR's fix hadn't targeted. Rebased this branch onto the new `main`, hit the same kind of structural conflict as step 5 (this time in the other direction - `main` now has the *new* shape, this branch's commit still targeted the *old* one), and resolved it the same way: kept `main`'s DaemonSet-manifest content and reapplied only the version-bump edit (`"image": "docker.io/istio/pilot:1.25.1"` -> `1.26.2`, plus the same CAUTION-comment update) directly against it, rather than trying to force the stale patch to apply.
9. Force-pushed the rebased branch.

</details>
