### PR TITLE
ci: bump pinned GitHub Actions to their latest major versions

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -59,6 +59,7 @@ jobs:
         id: setup-python
         with:
           python-version: '3.13'
+          pip-version: '26.2.1'
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -40,9 +40,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: opendatahub-io/odh-dashboard
           # Match the deployed dashboard image (components/04-odh-dashboard.yaml). `main` drifted;
@@ -55,7 +55,7 @@ jobs:
 
       # Otherwise we may end up with a random Python version?
       # https://github.com/jiridanek/rhoai-in-kind/issues/16
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         id: setup-python
         with:
           python-version: '3.13'
@@ -122,7 +122,7 @@ jobs:
 
       # https://pnpm.io/continuous-integration#github-actions
       - name: Use Node.js with npm caching
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20.x'
           cache: 'npm'
@@ -171,19 +171,19 @@ jobs:
         env:
           TEST_CASE: ${{ matrix.test_case }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-report-${{ steps.artifact-name.outputs.artifact-name }}
           path: odh-dashboard/frontend/src/__tests__/cypress/results/e2e/index.html
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots-${{ steps.artifact-name.outputs.artifact-name }}
           path: odh-dashboard/frontend/src/__tests__/cypress/results/e2e/screenshots
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: "!cancelled()"
         with:
           name: cypress-videos-${{ steps.artifact-name.outputs.artifact-name }}
@@ -208,7 +208,7 @@ jobs:
           PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
 
       - name: Archive cluster-logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: "steps.collect-logs.outputs.debug_bundle_dir != '' && !cancelled()"
         with:
           name: cluster-logs-${{ steps.artifact-name.outputs.artifact-name }}

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -39,6 +39,7 @@ jobs:
         id: setup-python
         with:
           python-version: '3.13'
+          pip-version: '26.2.1'
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1
@@ -77,16 +78,14 @@ jobs:
 
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
+      # No separate actions/setup-python step: `uv run` (below) provisions a Python interpreter
+      # matching opendatahub-tests/pyproject.toml's requires-python itself, downloading one if
+      # the runner's pre-installed interpreters don't already satisfy it.
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "opendatahub-tests/uv.lock"
-
-      - name: "Set up Python"
-        uses: actions/setup-python@v7
-        with:
-          python-version-file: "opendatahub-tests/pyproject.toml"
 
       - name: "Set up faked openshift oauth for oc client"
         run: |

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -25,9 +25,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: opendatahub-io/opendatahub-tests
           ref: 94670b336c632ac2c0022b347444b687d9384327  # Sept 18, 2025 - last known working
@@ -35,7 +35,7 @@ jobs:
 
       # Otherwise we may end up with a random Python version?
       # https://github.com/jiridanek/rhoai-in-kind/issues/16
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         id: setup-python
         with:
           python-version: '3.13'
@@ -78,13 +78,13 @@ jobs:
       # https://docs.astral.sh/uv/guides/integration/github/#installation
       # https://github.com/astral-sh/setup-uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "opendatahub-tests/uv.lock"
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: "opendatahub-tests/pyproject.toml"
 
@@ -119,7 +119,7 @@ jobs:
           PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
 
       - name: Archive cluster-logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: "steps.collect-logs.outputs.debug_bundle_dir != '' && !cancelled()"
         with:
           name: cluster-logs-${{ steps.artifact-name.outputs.artifact-name }}

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -178,9 +178,9 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: red-hat-data-services/ods-ci
           # Track the rhoai-2.25 stable line to match our pinned deployment (workbench v1.36.0,
@@ -191,7 +191,7 @@ jobs:
 
       # Otherwise we may end up with a random Python version?
       # https://github.com/jiridanek/rhoai-in-kind/issues/16
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         id: setup-python
         with:
           python-version: '3.13'
@@ -420,7 +420,7 @@ jobs:
           pipx install poetry
 
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: poetry
@@ -526,21 +526,21 @@ jobs:
           PYTHON3: "${{ steps.setup-python.outputs.python-path }}"
 
       - name: Archive cluster-logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: "steps.collect-logs.outputs.debug_bundle_dir != '' && !cancelled()"
         with:
           name: cluster-logs-${{ steps.artifact-name.outputs.artifact-name }}
           path: ${{ steps.collect-logs.outputs.debug_bundle_dir }}
 
       - name: Archive test-output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: "!cancelled()"
         with:
           name: test-output-${{ steps.artifact-name.outputs.artifact-name }}
           path: ods-ci/ods_ci/test-output
 
       - name: Archive chromedriver.log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: "!cancelled()"
         with:
           name: chromedriver-${{ steps.artifact-name.outputs.artifact-name }}

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -195,6 +195,7 @@ jobs:
         id: setup-python
         with:
           python-version: '3.13'
+          pip-version: '26.2.1'
 
       # Pulling large images (pytorch, tensorflow) we are otherwise running out of disk apace
       - name: Relocate docker data dir
@@ -423,6 +424,7 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+          pip-version: "26.2.1"
           cache: poetry
           cache-dependency-path: "ods-ci/poetry.lock"
 

--- a/components/05-ca-operator/kustomization.yaml
+++ b/components/05-ca-operator/kustomization.yaml
@@ -6,9 +6,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+# CAUTION: pinned to a commit, not refs/heads/master. On 2026-08-25 upstream merged a CRD
+# change (PR #2991, "GCD Promotion") that added a `format.dns1123Subdomain()` CEL validation
+# rule to the infrastructures CRD's status.platformStatus.gcp.universeDomain field. The CEL
+# "format" library isn't registered in the API server bundled in kindest/node:v1.31.6 (pinned
+# in components/00-kind-cluster.yaml / the workflows), so every kubectl apply of that CRD
+# failed with "undeclared reference to 'format'", breaking "Deploy stuff into Kubernetes" in
+# all three CI workflows simultaneously. b62ca02690 is the last commit before that merge -
+# re-pin to a newer commit (verify it doesn't reintroduce an incompatible CEL rule) if these
+# manifests need to move forward, rather than going back to a floating branch ref.
 resources:
-  - https://raw.githubusercontent.com/openshift/api/refs/heads/master/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
-  - https://raw.githubusercontent.com/openshift/api/refs/heads/master/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusteroperators.crd.yaml
-  - https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
-  - https://raw.githubusercontent.com/openshift/api/refs/heads/master/payload-command/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+  - https://raw.githubusercontent.com/openshift/api/b62ca02690/operator/v1/zz_generated.crd-manifests/0000_50_service-ca_02_servicecas.crd.yaml
+  - https://raw.githubusercontent.com/openshift/api/b62ca02690/config/v1/zz_generated.crd-manifests/0000_00_cluster-version-operator_01_clusteroperators.crd.yaml
+  - https://raw.githubusercontent.com/openshift/api/b62ca02690/payload-manifests/crds/0000_10_config-operator_01_infrastructures-Default.crd.yaml
+  - https://raw.githubusercontent.com/openshift/api/b62ca02690/payload-command/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
   - manifests.yaml


### PR DESCRIPTION
## Summary

- Bumps every pinned GitHub Action across the three CI workflows to its latest major version: `actions/checkout` v4→v7, `actions/setup-python` v5→v7, `actions/upload-artifact` v4→v7, `actions/setup-node` v4→v7, `astral-sh/setup-uv` v5→v10.0.1 (pinned exact, since v8+ dropped floating major/minor tags). `helm/kind-action` stays at `v1` — already a floating tag tracking the latest release.
- Fixes an unrelated CI-breaking issue discovered while validating this PR: `components/05-ca-operator/kustomization.yaml` floated on `openshift/api@master` for 4 CRD/CR manifests; upstream merged a change on 2026-08-25 that our pinned Kubernetes version can't validate. Pinned to the last-good commit.
- Adopts two new features unlocked by the version bumps: drops a redundant `actions/setup-python` step in the shiftleft workflow (uv provisions Python itself), and pins `pip-version` on every remaining `setup-python` step.

## Root cause (CI breakage, not the Actions bump itself)

`components/05-ca-operator/kustomization.yaml` fetched 4 manifests live from `https://raw.githubusercontent.com/openshift/api/refs/heads/master/...` on every CI run, never pinned. Upstream merged PR openshift/api#2991 ("GCD Promotion") on 2026-08-25 at 09:46 UTC, which added a `format.dns1123Subdomain()` CEL validation rule to the infrastructures CRD's `status.platformStatus.gcp.universeDomain` field. The CEL `format` library isn't registered in the API server bundled in `kindest/node:v1.31.6` (pinned elsewhere in this repo), so every `kubectl apply -k components/05-ca-operator` started failing with `undeclared reference to 'format'` — breaking the "Deploy stuff into Kubernetes" step identically across all three workflows, all matrix entries, 100% failure rate.

Confirmed this was pure timing, unrelated to the Actions bump: `main`'s own `odh-tests` workflow succeeded at 02:48 UTC that same day, before upstream's 09:46 UTC merge; this PR's CI ran later and hit the new commit. Pinned the 4 URLs to `b62ca02690`, the commit immediately before the breaking merge — verified locally with `kubectl kustomize components/05-ca-operator` that all 3 CRDs still build with zero occurrences of the incompatible CEL rule.

## Related issue

None filed — root-caused and fixed directly since it was blocking this PR's own CI.

## Test plan

- [x] Checked each Actions version jump's release notes for breaking changes applicable to this repo's actual usage (plain checkout, `name:`/`path:` artifact upload, python/node version-only setup, `uv` venv install). All bump to a Node 24 runtime, satisfied automatically by GitHub-hosted runners.
- [x] Verified `setup-uv` v6+'s no-longer-auto-activates-venv change doesn't apply, since this repo already runs tests via `uv run pytest ...`.
- [x] Verified (before applying) that `upload-artifact` v7's `archive: false` ignores the `name` input entirely — would have collided the ~17 parallel matrix jobs' chromedriver.log uploads onto one artifact name. Did not apply it; left as a regular archived upload with its existing per-matrix-entry name.
- [x] Verified `opendatahub-tests/pyproject.toml` has `requires-python = "==3.13.*"`, matching what the now-removed `setup-python` step used to pin, before removing it in favor of `uv run`'s own provisioning.
- [x] Ran `actionlint` against all three workflow files at every step — the two findings it reports (a stale `steps.artifact-name` reference in the shiftleft workflow, a shellcheck style nit in ods-ci) are confirmed pre-existing on `main`, unrelated to and unchanged by any commit in this PR.
- [x] Locally validated the CRD pin with `kubectl kustomize components/05-ca-operator`: builds successfully, produces all 3 expected CRDs, zero occurrences of `format.dns1123Subdomain`.
- [x] Full CI run on this PR, with the CRD-pin fix included: the systemic 100%-failure pattern is gone. `odh-tests` (the workflow whose `setup-python`/`setup-uv` steps this PR changes) passes cleanly. `cypress` and `ods-ci` each have a handful of individual test failures (1 and 4 jobs respectively, out of ~23 total) — checked one (`testWorkbenchImages.cy.ts`) and its failure is inside the actual Cypress test run step, not setup/deploy, consistent with this repo's known pre-existing test flakiness rather than anything introduced here.

### CI results (this PR, commit `880c253`)

| Workflow | Result |
|---|---|
| `odh-tests` | ✅ pass |
| `cypress` | ⚠️ 1/6 matrix jobs failed (`testWorkbenchImages.cy.ts`, failure inside the test run itself) |
| `ods-ci` | ⚠️ 4/17 matrix jobs failed (`custom-image.robot`, `minimal-pytorch-test.robot`, `minimal-tensorflow-test.robot`, `test-filling-pvc.robot`) |
| CodeQL / Analyze (actions, go, python) | ✅ pass |

<details>
<summary>Plan</summary>

No upfront plan document — this was worked through as a direct sequence: (1) enumerate and bump pinned Actions, checking breaking changes per jump; (2) discover all CI checks failing identically across every job/workflow, root-cause it via job logs down to the exact failing step and error; (3) trace the error to a floating (unpinned) upstream dependency and confirm via `openshift/api`'s own commit history and timing that it was unrelated to the Actions bump; (4) fix by pinning to the last-good commit, verified locally; (5) implement the previously-scoped-out new-version features (uv Python auto-provisioning, pip-version pin), explicitly re-verifying the `archive: false` idea against the actual README before applying it, since it turned out to be unsafe for this repo's matrix-parallel artifact-naming pattern.

</details>

<details>
<summary>Trajectory</summary>

1. Listed the three workflow files, confirmed no `dependabot.yml` exists, extracted every unique `uses:` action reference with `grep -rhoE "uses:\s*\S+"` and counted occurrences.
2. Queried `gh api repos/<owner>/<repo>/releases/latest` per action for current latest tags, then dispatched a research agent to check GitHub's release notes/changelogs for breaking changes in each jump scoped to this repo's actual usage patterns.
3. Verified the "setup-uv v8+ dropped floating tags" claim directly via `gh api repos/astral-sh/setup-uv/git/refs/tags/v10` (returns two prefix-matched refs, not one exact ref) vs. `actions/checkout`'s `refs/tags/v7` (resolves to one exact ref) — confirming why `setup-uv` needed an exact pin while the others didn't.
4. Checked the shiftleft workflow's actual test-execution line (`uv run pytest tests/workbenches ...`) to confirm it doesn't rely on implicit venv activation via PATH, so `setup-uv`'s v6+ auto-activation change didn't need an `activate-environment` addition.
5. Applied the version bumps via `sed` across all three files, verified with a grep/uniq -c pass, then ran `actionlint` — found two pre-existing issues, confirmed identical by stashing the changes and re-running against `main`'s original state.
6. Checked `git status`/`git log`: the branch previously used for an unrelated fix (`jd-fix-istio-prepull-version`) turned out to already be merged into `origin/main` as PR #74 with its remote branch deleted, so branched fresh off `origin/main` as `jd-bump-gha-actions`, staged only the three modified workflow files (repo has many unrelated untracked files), committed, and pushed.
7. Separately researched genuinely new *features* (not just breaking changes) in each bumped action via another research agent, focused on this repo's concrete patterns (multi-repo checkouts, matrix-derived artifact names sanitized by a hand-written Python step, `cache: poetry`/`cache: npm` usage, uv+setup-python double-step). Verified the standout claim — that `setup-uv` can replace the separate `setup-python` step — by checking `opendatahub-tests/pyproject.toml`'s actual `requires-python` value and cross-referencing `setup-uv`'s own README FAQ.
8. User asked to check CI on the opened PR before implementing those features. `gh pr checks 75` showed every single job across all three workflows failing, uniformly fast (~4 min each) — a strong signal of a common early-step failure rather than per-test flakiness.
9. Used `gh api .../jobs/<id>` to find the exact failing step ("Deploy stuff into Kubernetes") across a representative job, then pulled the full job log and grepped for `Error`/`Traceback`, landing on a CEL compilation error against the `infrastructures.config.openshift.io` CRD applied by `components/05-ca-operator`.
10. Cross-checked `main`'s most recent independent CI runs at the same commit (`af08b53`): the shiftleft workflow had succeeded a few hours earlier, while ods-ci/cypress had only a handful of matrix entries fail (normal flakiness, not the systemic failure seen on this PR) — ruling out both "always broken" and "caused by the Actions bump" as explanations.
11. Read `components/05-ca-operator/kustomization.yaml`, found it fetches 4 manifests live from `openshift/api@refs/heads/master` — an unpinned floating dependency. Queried `gh api repos/openshift/api/commits?path=...` for the infrastructures CRD file's commit history, found a merge landing at 09:46 UTC that day, matching the timing gap between main's last success and this PR's failure.
12. Verified via `curl` that the commit before the merge (`b62ca02690`) doesn't contain the `format.dns1123Subdomain` string while the current `master` does, and that all 4 required file paths resolve at that commit (HTTP 200 each).
13. Applied the pin, validated locally with `kubectl kustomize components/05-ca-operator` (3 CRDs, zero occurrences of the incompatible rule), committed as a separate, clearly-explained commit on the same branch.
14. Returned to the feature-adoption task: removed the shiftleft workflow's now-redundant `actions/setup-python` step (verified `opendatahub-tests/pyproject.toml`'s `requires-python = "==3.13.*"` first), added `pip-version: '26.2.1'` (checked via PyPI JSON API) to every remaining `setup-python` step.
15. Before applying the previously-recommended `archive: false` tweak to the chromedriver.log upload, re-verified its exact semantics via the `actions/upload-artifact` README rather than trusting the earlier research summary at face value — confirmed it ignores `name` entirely, which would break the ~17 parallel matrix jobs' need for unique artifact names. Skipped it and documented why in the commit message instead of silently applying a change that looked good in isolation but was wrong for this specific workflow's shape.
16. Ran `actionlint` one final time across all three files, confirmed only the same two pre-existing findings, committed, and pushed.

</details>
