### PR TITLE
ci: bump pinned kind CLI to v0.32.0

### DIFF
--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -70,7 +70,7 @@ jobs:
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.27.0
+          version: v0.32.0
           # Dashboard tests fail on k8s 1.32
           # https://hub.docker.com/r/kindest/node/tags
           node_image: "docker.io/kindest/node:v1.31.6"

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -50,7 +50,7 @@ jobs:
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.27.0
+          version: v0.32.0
           # Dashboard tests fail on k8s 1.32
           # https://hub.docker.com/r/kindest/node/tags
           # Let's keep using same version as for dashboard then

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -212,7 +212,7 @@ jobs:
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.27.0
+          version: v0.32.0
           # Dashboard tests fail on k8s 1.32
           # https://hub.docker.com/r/kindest/node/tags
           # Let's keep using same version as for dashboard then


### PR DESCRIPTION
## Summary

Bumps the `kind` CLI version (`helm/kind-action`'s `version:` input) from v0.27.0 to v0.32.0 across all three CI workflows - 5 minor releases behind. `node_image` stays pinned at `kindest/node:v1.31.6` (unchanged - existing comment: "Dashboard tests fail on k8s 1.32").

## Root cause

Not a bug fix - routine version maintenance, split out as its own PR since #74 (Actions bump) already merged separately.

## Test plan

- [x] Checked kind's release notes (v0.28 through v0.32) for anything affecting this repo's `kind.x-k8s.io/v1alpha4` config + `kubeadmConfigPatches`, or `kind load docker-image`. Nothing applies.
- [x] Confirmed the one relevant v0.32.0 change (kubeadm v1beta4 adoption) only activates for Kubernetes 1.36+; kind still generates v1beta3 kubeadm config for the pinned 1.31.6 node image, so cluster creation goes through the same code path as before.
- [x] Confirmed kind has no hard version-gated cutoff for older node images (best-effort support) - v1.31 falls outside v0.32.0's actively-*tested* window (current+3 minors = 1.33-1.36) but that's a testing-scope note, not an enforced compatibility break.
- [ ] Full CI run on this PR (the actual empirical test of whether v0.32.0 + node_image v1.31.6 still creates a working cluster)

<details>
<summary>Trajectory</summary>

1. User asked to "update kind" - disambiguated between `helm/kind-action` (the GitHub Action wrapper, already a floating `v1` tag tracking latest, no change needed) and the `kind` CLI version it pins internally (`version: v0.27.0`, 5 minors behind latest `v0.32.0`) - the latter is the real, meaningful gap.
2. Confirmed `node_image: kindest/node:v1.31.6` is deliberately unrelated and not to be touched, per the existing "Dashboard tests fail on k8s 1.32" comment already in the workflow files.
3. Dispatched a research pass through kind's own GitHub releases (`gh api repos/kubernetes-sigs/kind/releases`) across the v0.28-v0.32 range, scoped to this repo's actual config shape (v1alpha4, kubeadmConfigPatches setting `maxParallelImagePulls`, `kind load docker-image` used directly in one step) and specifically the node-image compatibility question, since the pinned node image is 5 kind-releases older than the CLI being adopted.
4. Findings: no breaking changes apply to this config across the whole range; the only relevant v0.32.0 change (kubeadm v1beta4) only affects Kubernetes 1.36+ clusters, so the 1.31.6 node image still goes through kind's existing v1beta3 kubeadm-config generation path unchanged. kind's compatibility policy has never been a hard version gate - "older images ... should continue to work ... but are not guaranteed" - v1.31 simply falls outside the current release's actively-tested current+3-minors window (1.33-1.36) without an announced compatibility break.
5. Applied the bump via `sed` across all three workflow files, validated with `actionlint` (only the same two pre-existing, unrelated findings from before), and committed.
6. On push, discovered PR #75 (the prior Actions-bump PR this commit was originally going to append to) had already been merged - `git log` showed a merge commit for it now in this branch's ancestry, and the remote branch name got silently recreated by the push (GitHub normally deletes a branch after merge). Opened this as its own separate PR instead of assuming it would append to the already-closed one.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the KinD environment setup used by automated validation workflows.
  - Improved consistency and reliability of test cluster provisioning across CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->