### PR TITLE
ci: remove redundant local-path-provisioner install

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -370,17 +370,18 @@ def main():
         # need status for dashboard resource otherwise notebook controller will not fill dashboard link for dspa secret
         sh("kubectl apply -f components/07-dsc-dsci.yaml --server-side --subresource=status || true")
 
-    with gha_log_group("Install local-path provisioner"):
-        sh("kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.33/deploy/local-path-storage.yaml")
-        tf.defer(None, lambda _: sh(
-            "kubectl wait deployments --all --namespace=local-path-storage --for=condition=Available --timeout=100s"))
-        # https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/
-        sh("kubectl get storageclass")
-        # kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
-        # dashboard tests expect a storage class that's identified by
+    with gha_log_group("Check storage class"):
+        # kind already creates its own default StorageClass at cluster creation time (named
+        # "standard", provisioner rancher.io/local-path, annotated is-default-class: "true") -
+        # this used to also `kubectl apply` rancher/local-path-provisioner's own upstream
+        # manifest on top of that, which just installed a second, non-default StorageClass
+        # named "local-path" that nothing referenced (confirmed via a real CI run's `kubectl
+        # get storageclass` output: only "standard" was ever marked (default), the manually
+        # installed "local-path" one sat unused). Dashboard tests look up whichever class
+        # carries the is-default-class annotation dynamically, not by a hardcoded name - see
         # > oc get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
-        # and the above delivers, so nothing more to do here
-        # most importantly, don't create another `storageclass.kubernetes.io/is-default-class: "true"` thing or the above command returns both, space separated
+        # - so kind's own bundled StorageClass already satisfies that without any extra step.
+        sh("kubectl get storageclass")
 
     with gha_log_group("Run deferred functions"):
         with tf:


### PR DESCRIPTION
## Summary

Removes `components/deploy.py`'s "Install local-path provisioner" step, which manually applied `rancher/local-path-provisioner`'s own upstream manifest on top of a kind cluster. Confirmed via a real CI run's `kubectl get storageclass` output that kind already creates its own default StorageClass (`standard`, provisioner `rancher.io/local-path`, `is-default-class: "true"`) at cluster creation time - this step just installed a second, non-default, unused `local-path` StorageClass alongside it.

## Root cause

Traced back to commit aae0595 (April 2025, "Downgrade k8s because dashboard tests are incompatible with v1.32"), which bundled two unrelated things: (1) pinning `node_image` to `kindest/node:v1.31.6`, and (2) installing this local-path-provisioner step to create a StorageClass explicitly named `standard-csi`, matching odh-dashboard's Cypress tests' then-hardcoded expectation - unrelated to the Kubernetes version itself. The hardcoded-name hack was already dropped by the time this branch's current `deploy.py` was written (it now just relies on the `is-default-class` annotation, matching how dashboard tests look up the storage class today per `oc get storageclass -o jsonpath='{...is-default-class=="true"...}'`), but the now-pointless extra provisioner install was left behind.

Grepped this repo's own `components/` and test-variable configs for any hardcoded reference to a StorageClass named `local-path` - found none, confirming nothing depends on the manually-installed one.

## Related issue

None filed - discovered while researching whether the `node_image` pin from the same original commit can be lifted (a separate, follow-up change, not included here).

## Test plan

- [x] Verified locally: `python3 -m py_compile components/deploy.py` succeeds.
- [x] Confirmed via a real CI job's log (`kubectl get storageclass` output already runs in every job) that `standard (default)` was the only class ever marked default; the manually-installed `local-path` class sat unused.
- [x] Grepped `components/` for any other reference to the `local-path` StorageClass name - none found.
- [ ] Full CI run on this PR - the actual empirical test of whether removing this step breaks anything in the dashboard/ods-ci/opendatahub-tests suites

<details>
<summary>Trajectory</summary>

1. User asked to research why `node_image` (pinned to `kindest/node:v1.31.6`) couldn't be updated, referencing an existing "Dashboard tests fail on k8s 1.32" comment with no further explanation or linked issue.
2. Found the original commit (`aae0595`, April 2025) via `git log -S`, which bundled the `node_image` pin together with installing a StorageClass explicitly named `standard-csi` (the literal default StorageClass name on GCP-backed OpenShift, per this repo's own `ods-ci` fixtures) to match odh-dashboard's then-hardcoded Cypress fixture expectation.
3. Dispatched a research agent across `openshift/api`... no, across `odh-dashboard`'s GitHub issues/PRs/cypress fixtures and the Kubernetes 1.32 changelog: found no documented k8s-1.32-specific storage/CSI/PVC change that would explain a real incompatibility, and found that odh-dashboard's Cypress tests at the currently-pinned `v2.37.1-odh` ref already use a dynamic `getOpenshiftDefaultStorageClass()` lookup instead of the old hardcoded `standard-csi` name.
4. Verified locally that `components/deploy.py` already reflects this: it no longer creates a `standard-csi`-named class, just installs local-path-provisioner and comments that the `is-default-class` annotation is what dashboard tests actually look up.
5. User asked to try undoing the StorageClass workaround first (as an isolated step before touching `node_image`). Investigated what "workaround" remained given the hardcoded-name hack was already gone: checked `components/00-kind-cluster.yaml` for anything disabling kind's built-in storage provisioning (nothing), then pulled a real, recent green CI job's log and grepped for its own `kubectl get storageclass` output.
6. That log showed two StorageClasses: `standard (default)` (age matching cluster creation) and `local-path` (age matching the just-run provisioner-install step, not marked default) - proving kind's bundled provisioner already satisfies the actual requirement, and the manual install is pure dead weight.
7. Grepped this repo's own `components/` tree for any reference to a StorageClass named `local-path` to confirm nothing else depends on it, found none.
8. Removed the step, replacing it with just the `kubectl get storageclass` diagnostic call and an explanatory comment, verified Python syntax, and branched fresh off `origin/main` (not the not-yet-merged kind-CLI-bump branch) to keep this an isolated, independently-testable change.

</details>