### PR TITLE
add run-rhoai-in-kind skill: bring up the local stack and drive its dashboard

### DIFF
--- a/.claude/skills/run-rhoai-in-kind/.gitignore
+++ b/.claude/skills/run-rhoai-in-kind/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+screenshots/

--- a/.claude/skills/run-rhoai-in-kind/SKILL.md
+++ b/.claude/skills/run-rhoai-in-kind/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: run-rhoai-in-kind
+description: Build, run, and drive rhoai-in-kind - spins up a local kind Kubernetes cluster running an OpenShift AI / Open Data Hub-like stack (dashboard, notebook controller, DSPO, Kyverno polyfills) and lets you interact with the real dashboard UI. Use when asked to run this project, bring up the local cluster, redeploy after a components/ change, take a screenshot of the dashboard, or verify a change against the real running stack instead of just reading CI logs.
+---
+
+This isn't a single app - it's CI infrastructure that recreates a local
+kind cluster, deploys an ODH-Dashboard-like stack onto it via
+`components/deploy.py`, and drives the resulting web UI with a Playwright
+script (`.claude/skills/run-rhoai-in-kind/driver.mjs`). All paths below
+are relative to the repo root.
+
+## Prerequisites
+
+macOS with Apple Silicon (this was verified on `darwin/arm64`; the CI
+equivalent runs on `ubuntu-latest` and doesn't need any of the podman/
+Rosetta steps below - see `.github/workflows/*.yaml` for that path).
+
+```bash
+# Podman machine, rootful, with Rosetta so amd64-only ODH images don't
+# crash (SIGSEGV / lfstack) - one-time setup:
+mkdir -p ~/.config/containers && printf '[machine]\nrosetta = true\n' >> ~/.config/containers/containers.conf
+podman machine init --rootful --memory $((16 * 1024)) --cpus 4
+podman machine start
+```
+
+```bash
+kind version   # v0.32.0 verified working
+kubectl version --client
+python3 --version   # needs 3.13, per pyproject.toml requires-python
+node --version   # v26.7.0 verified working even though CI pins Node 20 -
+                 # this repo's own tooling has no Node-version-specific code
+```
+
+Python deps: `.venv/` already exists at repo root (uv-managed, `boto3`
+for `deploy.py`'s MinIO/S3 bucket provisioning). If missing: `uv sync`.
+
+## Setup / Build
+
+No compile step. "Building" this project means recreating the cluster:
+
+```bash
+kind delete cluster --name kind   # only if one already exists
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
+```
+
+`kind create cluster` sets kubeconfig's current-context to `kind-kind`
+as a side effect - verify rather than assume:
+
+```bash
+kubectl config current-context   # must print kind-kind
+kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}'   # must be https://127.0.0.1:6443
+```
+
+**This kubeconfig has ~100 contexts, several of them real production
+clusters.** Never assume the current-context is local. Prefer pinning
+`--context kind-kind` on individual `kubectl`/`oc` calls over globally
+switching context with `kubectl config use-context` (the latter mutates
+shared state for every other shell/tool until something switches it
+back - see [[cluster-context-safety]] memory). `components/deploy.py`
+itself has no `--context` flag and relies on the ambient current-context,
+which is why the explicit verification above matters before running it.
+
+## Run (agent path)
+
+Deploy the stack, then drive the resulting dashboard with the Playwright
+script:
+
+```bash
+.venv/bin/python3 components/deploy.py --workbench-branch=v1.36.0
+```
+
+Takes several minutes (Kyverno, Istio, ArgoCD-synced ODH Dashboard,
+DSC/DSCI, local-path storage check - see the `::group::` sections in its
+output). Ends with the dashboard reachable at
+`https://rhods-dashboard.127.0.0.1.sslip.io/`.
+
+Then drive it:
+
+```bash
+cd .claude/skills/run-rhoai-in-kind
+npm install                       # one-time: installs playwright
+npx playwright install chromium   # one-time: downloads the browser binary
+node driver.mjs login-screenshot [output.png]   # default: ./screenshots/dashboard.png
+```
+
+`driver.mjs` reads admin credentials from the repo root's
+`test-variables.yml` (`OCP_ADMIN_USER` block: `adm-auth` /
+`adminuser` / `adminuser-passwd`), launches headless Chromium with
+`ignoreHTTPSErrors: true` (the oauth-proxy serves a self-signed cert),
+submits the `/oauth/start` form, clicks the `adm-auth` identity-provider
+link, fills the login form, waits for the "Data Science Projects" home
+page element, and screenshots. One command, one function
+(`login-screenshot`) today - it's a starting point, not a full REPL;
+extend it with more `page.locator(...)` calls for whatever flow you
+need to verify next, following the same pattern.
+
+**For real feature verification** (not just "did it come up"), drive it
+through the project's own vendored e2e suites instead of hand-rolling
+more Playwright calls - they already exist and are more thorough:
+
+```bash
+# Cypress (odh-dashboard) - e.g. the workbench+PVC/volume-attach test:
+git clone --branch v2.37.1-odh --depth 1 https://github.com/opendatahub-io/odh-dashboard.git odh-dashboard
+cd odh-dashboard && npm ci --prefer-offline --no-audit
+cd frontend
+TERM=xterm-256color CY_TEST_CONFIG="$(pwd)/../../test-variables.yml" \
+  npm run cypress:run -- --spec '**/workbenches/workbenches.cy.ts'
+```
+
+Results land in `odh-dashboard/frontend/src/__tests__/cypress/results/e2e/`
+(`index.html` report; screenshots only on failure, video off by default
+in this repo's CI config).
+
+```bash
+# ods-ci (robot framework) and opendatahub-tests (pytest) follow the
+# same pattern as their CI steps in .github/workflows/rhoai-in-kind-with-
+# ods-ci.yaml / -shiftleft.yaml - checkout at the pinned ref, install
+# deps (poetry / uv), run against the same live cluster.
+```
+
+## Run (human path)
+
+Open `https://rhods-dashboard.127.0.0.1.sslip.io/` in a real browser and
+click "Log in with OpenShift" → `adm-auth` → `adminuser` /
+`adminuser-passwd` (self-signed cert warning: click through it, same as
+[[chrome-devtools-self-signed-cert-bypass]]). Tear down with
+`kind delete cluster --name kind`.
+
+## Test
+
+See `## Run (agent path)`'s e2e section above - this project's "tests"
+*are* driving the running app (cypress/ods-ci/opendatahub-tests), there's
+no separate unit-test-only command. `python3 -m py_compile components/*.py`
+is a fast sanity check after editing `deploy.py`, not a real test.
+
+---
+
+## Gotchas
+
+- **`test-variables.yml`'s `TEST_USER` block (`AUTH_TYPE: foo-auth`) is
+  not a real identity provider in this repo's local oauth-server setup.**
+  The actual configured IDPs are `adm-auth` / `contributor-auth` /
+  `ldap-provider-qe` (from `components/opendatahub-tests/openldap.yaml`).
+  Use the `OCP_ADMIN_USER` block instead. Confirmed by `curl`-ing the
+  oauth-server's actual login page and reading the rendered `<a>` links
+  rather than guessing from the yaml.
+- **npm's newer default script-allowlist silently skips Cypress's own
+  postinstall** (`npm warn install-scripts ... cypress@... (postinstall:
+  node index.js --exec install)`), which is what downloads the Cypress
+  binary. `npm ci` still exits 0. Check with `npx cypress verify` before
+  assuming the binary is there - if missing, `npx cypress install`.
+- **Playwright needs its browser binary downloaded separately from the
+  npm package** (`browserType.launch: Executable doesn't exist at
+  .../chrome-headless-shell`) - `npm install playwright` alone isn't
+  enough, always follow with `npx playwright install chromium`.
+- **`ignoreHTTPSErrors: true` on the Playwright context** is the
+  equivalent of manually clicking through Chrome's self-signed-cert
+  interstitial - much simpler than the chrome-devtools MCP click-through
+  approach when scripting rather than driving interactively.
+- **`kind create cluster` changes kubeconfig's current-context as a
+  side effect.** If the workflow is delete-then-recreate-then-deploy (the
+  normal local loop), this often makes an explicit context switch
+  unnecessary - just verify with `kubectl config current-context`
+  immediately before `deploy.py` rather than assuming either way.
+- **The dashboard's default StorageClass comes from kind itself**
+  (`standard`, provisioner `rancher.io/local-path`, annotated
+  `is-default-class: "true"` at cluster-creation time) - `deploy.py`
+  does NOT need to install a separate provisioner or create a
+  specially-named StorageClass; dashboard/cypress code looks the default
+  class up dynamically via that annotation, not by a hardcoded name.
+
+## Troubleshooting
+
+- **`locator.click: Timeout ... waiting for getByRole('link', { name:
+  'foo-auth' })`**: wrong IDP name - see the `test-variables.yml` gotcha
+  above, use `adm-auth`.
+- **`kubectl get storageclass` shows two classes, only one
+  `(default)`**: harmless if intentional (e.g. testing an older
+  `deploy.py` revision that still installs `rancher/local-path-
+  provisioner`'s own manifest) - only the one flagged `(default)`
+  matters; the extra one is inert unless something references it by name.
+- **`Error from server (Forbidden)` on ordinary `kubectl get`
+  commands**: current-context is a remote cluster, not `kind-kind`. Run
+  `kubectl config current-context` and fix before continuing - don't
+  assume permission errors mean something is broken locally.

--- a/.claude/skills/run-rhoai-in-kind/driver.mjs
+++ b/.claude/skills/run-rhoai-in-kind/driver.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Drives the ODH Dashboard running on the local kind cluster with Playwright.
+// Requires `npx playwright` (chromium) available - see SKILL.md Prerequisites.
+//
+// Usage:
+//   node driver.mjs login-screenshot [output.png]
+//
+// Reads credentials from test-variables.yml (repo root) TEST_USER block.
+
+import { chromium } from "playwright";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const DASHBOARD_URL = "https://rhods-dashboard.127.0.0.1.sslip.io/";
+
+function readTestVariables() {
+  const raw = fs.readFileSync(path.join(REPO_ROOT, "test-variables.yml"), "utf8");
+  // Minimal YAML scrape - avoids adding a yaml dependency for 3 fields.
+  // OCP_ADMIN_USER (adm-auth), not TEST_USER (foo-auth) - foo-auth isn't a real IDP
+  // in this repo's local oauth-server setup (components/opendatahub-tests/openldap.yaml
+  // configures adm-auth/contributor-auth/ldap-provider-qe); confirmed by fetching the
+  // actual oauth-server login page and reading its rendered IDP links.
+  const block = raw.split(/^OCP_ADMIN_USER:/m)[1].split(/^\S/m)[0];
+  const get = (key) => block.match(new RegExp(`${key}:\\s*(\\S+)`))[1].replace(/^["']|["']$/g, "");
+  return { authType: get("AUTH_TYPE"), username: get("USERNAME"), password: get("PASSWORD") };
+}
+
+async function loginScreenshot(outPath) {
+  const { authType, username, password } = readTestVariables();
+  const browser = await chromium.launch();
+  // ignoreHTTPSErrors: the dashboard's oauth-proxy serves a self-signed cert.
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+
+  await page.goto(DASHBOARD_URL, { waitUntil: "domcontentloaded" });
+
+  // If already logged in (e.g. reused browser state) this form won't exist - skip login.
+  const oauthForm = page.locator('form[action="/oauth/start"]');
+  if (await oauthForm.count()) {
+    await oauthForm.evaluate((f) => f.submit());
+    await page.getByRole("link", { name: authType }).last().click();
+    await page.locator('input[name="username"]').fill(username);
+    await page.locator('input[name="password"]').fill(password);
+    await page.locator("form").evaluate((f) => f.submit());
+  }
+
+  // Wait for a known post-login dashboard element rather than a fixed sleep.
+  await page.waitForSelector("text=Data Science Projects", { timeout: 30000 });
+
+  await page.screenshot({ path: outPath, fullPage: true });
+  await browser.close();
+  console.log(`Screenshot written to ${outPath}`);
+}
+
+const [cmd, outArg] = process.argv.slice(2);
+const outPath = outArg || path.join(__dirname, "screenshots", "dashboard.png");
+
+switch (cmd) {
+  case "login-screenshot":
+    await loginScreenshot(outPath);
+    break;
+  default:
+    console.error("Usage: node driver.mjs login-screenshot [output.png]");
+    process.exit(1);
+}

--- a/.claude/skills/run-rhoai-in-kind/driver.mjs
+++ b/.claude/skills/run-rhoai-in-kind/driver.mjs
@@ -5,7 +5,8 @@
 // Usage:
 //   node driver.mjs login-screenshot [output.png]
 //
-// Reads credentials from test-variables.yml (repo root) TEST_USER block.
+// Reads the dashboard URL and admin credentials from test-variables.yml
+// (repo root): ODH_DASHBOARD_URL and the OCP_ADMIN_USER block.
 
 import { chromium } from "playwright";
 import fs from "node:fs";
@@ -14,45 +15,53 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
-const DASHBOARD_URL = "https://rhods-dashboard.127.0.0.1.sslip.io/";
 
 function readTestVariables() {
   const raw = fs.readFileSync(path.join(REPO_ROOT, "test-variables.yml"), "utf8");
-  // Minimal YAML scrape - avoids adding a yaml dependency for 3 fields.
+  // Minimal YAML scrape - avoids adding a yaml dependency for a handful of fields.
+  const dashboardUrl = raw.match(/^ODH_DASHBOARD_URL:\s*"?([^"\s]+)"?/m)[1];
   // OCP_ADMIN_USER (adm-auth), not TEST_USER (foo-auth) - foo-auth isn't a real IDP
   // in this repo's local oauth-server setup (components/opendatahub-tests/openldap.yaml
   // configures adm-auth/contributor-auth/ldap-provider-qe); confirmed by fetching the
   // actual oauth-server login page and reading its rendered IDP links.
   const block = raw.split(/^OCP_ADMIN_USER:/m)[1].split(/^\S/m)[0];
   const get = (key) => block.match(new RegExp(`${key}:\\s*(\\S+)`))[1].replace(/^["']|["']$/g, "");
-  return { authType: get("AUTH_TYPE"), username: get("USERNAME"), password: get("PASSWORD") };
+  return {
+    dashboardUrl,
+    authType: get("AUTH_TYPE"),
+    username: get("USERNAME"),
+    password: get("PASSWORD"),
+  };
 }
 
 async function loginScreenshot(outPath) {
-  const { authType, username, password } = readTestVariables();
+  const { dashboardUrl, authType, username, password } = readTestVariables();
   const browser = await chromium.launch();
-  // ignoreHTTPSErrors: the dashboard's oauth-proxy serves a self-signed cert.
-  const context = await browser.newContext({ ignoreHTTPSErrors: true });
-  const page = await context.newPage();
+  try {
+    // ignoreHTTPSErrors: the dashboard's oauth-proxy serves a self-signed cert.
+    const context = await browser.newContext({ ignoreHTTPSErrors: true });
+    const page = await context.newPage();
 
-  await page.goto(DASHBOARD_URL, { waitUntil: "domcontentloaded" });
+    await page.goto(dashboardUrl, { waitUntil: "domcontentloaded" });
 
-  // If already logged in (e.g. reused browser state) this form won't exist - skip login.
-  const oauthForm = page.locator('form[action="/oauth/start"]');
-  if (await oauthForm.count()) {
-    await oauthForm.evaluate((f) => f.submit());
-    await page.getByRole("link", { name: authType }).last().click();
-    await page.locator('input[name="username"]').fill(username);
-    await page.locator('input[name="password"]').fill(password);
-    await page.locator("form").evaluate((f) => f.submit());
+    // If already logged in (e.g. reused browser state) this form won't exist - skip login.
+    const oauthForm = page.locator('form[action="/oauth/start"]');
+    if (await oauthForm.count()) {
+      await oauthForm.evaluate((f) => f.submit());
+      await page.getByRole("link", { name: authType }).last().click();
+      await page.locator('input[name="username"]').fill(username);
+      await page.locator('input[name="password"]').fill(password);
+      await page.locator("form").evaluate((f) => f.submit());
+    }
+
+    // Wait for a known post-login dashboard element rather than a fixed sleep.
+    await page.waitForSelector("text=Data Science Projects", { timeout: 30000 });
+
+    await page.screenshot({ path: outPath, fullPage: true });
+    console.log(`Screenshot written to ${outPath}`);
+  } finally {
+    await browser.close();
   }
-
-  // Wait for a known post-login dashboard element rather than a fixed sleep.
-  await page.waitForSelector("text=Data Science Projects", { timeout: 30000 });
-
-  await page.screenshot({ path: outPath, fullPage: true });
-  await browser.close();
-  console.log(`Screenshot written to ${outPath}`);
 }
 
 const [cmd, outArg] = process.argv.slice(2);

--- a/.claude/skills/run-rhoai-in-kind/package-lock.json
+++ b/.claude/skills/run-rhoai-in-kind/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "run-rhoai-in-kind-driver",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "run-rhoai-in-kind-driver",
+      "dependencies": {
+        "playwright": "^1.62.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/.claude/skills/run-rhoai-in-kind/package.json
+++ b/.claude/skills/run-rhoai-in-kind/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "run-rhoai-in-kind-driver",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "playwright": "^1.62.1"
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/skills/run-rhoai-in-kind/`, a Claude Code skill that documents and scripts the local dev loop for this project: recreate the kind cluster, run `components/deploy.py`, and actually interact with the resulting ODH Dashboard UI - not just read CI logs.

## What's included

- `SKILL.md` - prerequisites (podman/Rosetta on Apple Silicon, kind, uv-managed venv), the cluster recreate + `deploy.py` bring-up sequence, cluster-context safety notes, and how to drive the dashboard both via the new driver and via the project's own vendored e2e suites (cypress/ods-ci/opendatahub-tests) for real feature verification.
- `driver.mjs` - a small Playwright script (`login-screenshot` command) that logs into the dashboard's oauth-proxy (self-signed cert, `adm-auth` identity provider) and screenshots the landing page.
- `package.json`/`package-lock.json` - pins `playwright` as the driver's only dependency, installed via a one-time `npm install` inside the skill directory.

## Test plan

- [x] Ran the full documented sequence for real this session: recreated the local kind cluster, ran `deploy.py`, then `driver.mjs login-screenshot` - produced a real screenshot of the live dashboard (verified by actually looking at it, not just checking the script exited 0).
- [x] Verified `SKILL.md` is accurate by re-running it from a clean state: `rm -rf node_modules screenshots package-lock.json`, then `npm install` → `npx playwright install chromium` → `node driver.mjs login-screenshot` exactly as documented, with no improvisation needed.
- [x] Also ran the project's real e2e suite (`odh-dashboard`'s `workbenches.cy.ts` cypress test) against the same local cluster as a deeper verification path, documented as the recommended route for actual feature testing rather than extending the driver script indefinitely.

<details>
<summary>Trajectory</summary>

1. Command `/run-skill-generator` was invoked to produce a skill that lets a future agent build/launch/drive this project from a clean machine.
2. Checked for an existing run-skill first (per the generator's own process) - none found, only `ci-triage`.
3. Determined this project's "app" is the ODH Dashboard web UI that `components/deploy.py` stands up on a local kind cluster - a "Browser-driven web app" per the generator's project-type table, for which the recommended off-the-shelf driver is `chromium-cli`. Checked: not installed in this environment (`chromium-cli: command not found`).
4. Fell back to the generator's documented alternative: a custom Playwright script, since `npx playwright --version` worked and a chromium binary was already cached locally.
5. Wrote `driver.mjs` to log in via the dashboard's oauth-proxy flow, based on reading `odh-dashboard`'s own cypress login command (`visitWithLogin` in `application.ts`) to get the exact form/selector sequence: submit `form[action="/oauth/start"]`, click the identity-provider link, fill `username`/`password`, submit.
6. First attempt used `test-variables.yml`'s `TEST_USER` block (`AUTH_TYPE: foo-auth`) and failed - `curl`-ed the actual oauth-server login page directly and found the real configured identity providers are `adm-auth`/`contributor-auth`/`ldap-provider-qe`, not `foo-auth`. Switched to `OCP_ADMIN_USER` (`adm-auth`/`adminuser`/`adminuser-passwd`), which matched, logged in successfully, and captured a real screenshot - then actually looked at the image to confirm it showed the real dashboard (Data Science Projects list including namespaces left over from this session's earlier testing), not a blank or error page.
7. Hit and documented two more real setup snags: npm's newer default script-allowlist silently skipped Cypress's own postinstall (caught via `npx cypress verify`, not by assuming success), and Playwright needing a separate `npx playwright install chromium` step beyond `npm install`.
8. Verified `SKILL.md`'s documented sequence from a clean state (deleted `node_modules`/`screenshots`/lockfile, re-ran every command as written) to make sure nothing in the writeup required undocumented improvisation.
9. Added `.gitignore` for `node_modules/`/`screenshots/` so only the actual skill + driver + dependency manifest get committed.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance for building, running, and testing the application on a local Kubernetes cluster.
  - Added automated browser login and full-page dashboard screenshot capture.
  - Added setup documentation covering prerequisites, testing workflows, and troubleshooting.

- **Chores**
  - Added Playwright tooling for browser automation.
  - Excluded generated dependencies and screenshots from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->