### PR TITLE
ci: bump node_image v1.31.6 -> v1.34.11, digest-pinned

### DIFF
--- a/.claude/skills/run-rhoai-in-kind/SKILL.md
+++ b/.claude/skills/run-rhoai-in-kind/SKILL.md
@@ -40,7 +40,7 @@ No compile step. "Building" this project means recreating the cluster:
 
 ```bash
 kind delete cluster --name kind   # only if one already exists
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 ```
 
 `kind create cluster` sets kubeconfig's current-context to `kind-kind`

--- a/.claude/skills/run-rhoai-in-kind/SKILL.md
+++ b/.claude/skills/run-rhoai-in-kind/SKILL.md
@@ -40,7 +40,7 @@ No compile step. "Building" this project means recreating the cluster:
 
 ```bash
 kind delete cluster --name kind   # only if one already exists
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998
 ```
 
 `kind create cluster` sets kubeconfig's current-context to `kind-kind`

--- a/.claude/skills/run-rhoai-in-kind/SKILL.md
+++ b/.claude/skills/run-rhoai-in-kind/SKILL.md
@@ -40,7 +40,7 @@ No compile step. "Building" this project means recreating the cluster:
 
 ```bash
 kind delete cluster --name kind   # only if one already exists
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d
 ```
 
 `kind create cluster` sets kubeconfig's current-context to `kind-kind`

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -66,7 +66,7 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
@@ -87,7 +87,7 @@ jobs:
           # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
           # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -66,20 +66,28 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # kind v0.32.0's own default node image (its release notes recommend pinning by
-          # digest, not just tag, until node images get a different tagging scheme).
+          # Pinned to v1.34.11 rather than kind v0.32.0's own newer default node image
+          # (v1.36.1) - kind release notes recommend pinning by digest, not just tag, until node
+          # images get a different tagging scheme, which this still does.
           # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
           # comment that turned out to be unrelated to the Kubernetes version at all (see
-          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
+          # components/deploy.py's "Check storage class" step and PR #77).
+          # v1.36.1 was tried and reverted (see issue #98): Kubernetes v1.35 kubelet dropped the
+          # container name from Created/Started event messages ("Container created" instead of
+          # "Created container: <name>"), which breaks odh-dashboard's message-based oauth-proxy
+          # detection in the Workbench status Progress tab (testWorkbenchControlSuite.cy.ts,
+          # testWorkbenchStatus.cy.ts) - confirmed via kubelet source diff and unfixed on
+          # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
+          # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-cypress.yaml
+++ b/.github/workflows/rhoai-in-kind-with-cypress.yaml
@@ -63,17 +63,23 @@ jobs:
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1
+      # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
+      # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.31.6; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # Dashboard tests fail on k8s 1.32
+          # kind v0.32.0's own default node image (its release notes recommend pinning by
+          # digest, not just tag, until node images get a different tagging scheme).
+          # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
+          # comment that turned out to be unrelated to the Kubernetes version at all (see
+          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.31.6"
+          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -46,7 +46,7 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
@@ -67,7 +67,7 @@ jobs:
           # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
           # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -43,18 +43,23 @@ jobs:
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1
+      # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
+      # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.31.6; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # Dashboard tests fail on k8s 1.32
+          # kind v0.32.0's own default node image (its release notes recommend pinning by
+          # digest, not just tag, until node images get a different tagging scheme).
+          # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
+          # comment that turned out to be unrelated to the Kubernetes version at all (see
+          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
           # https://hub.docker.com/r/kindest/node/tags
-          # Let's keep using same version as for dashboard then
-          node_image: "docker.io/kindest/node:v1.31.6"
+          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -46,20 +46,28 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # kind v0.32.0's own default node image (its release notes recommend pinning by
-          # digest, not just tag, until node images get a different tagging scheme).
+          # Pinned to v1.34.11 rather than kind v0.32.0's own newer default node image
+          # (v1.36.1) - kind release notes recommend pinning by digest, not just tag, until node
+          # images get a different tagging scheme, which this still does.
           # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
           # comment that turned out to be unrelated to the Kubernetes version at all (see
-          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
+          # components/deploy.py's "Check storage class" step and PR #77).
+          # v1.36.1 was tried and reverted (see issue #98): Kubernetes v1.35 kubelet dropped the
+          # container name from Created/Started event messages ("Container created" instead of
+          # "Created container: <name>"), which breaks odh-dashboard's message-based oauth-proxy
+          # detection in the Workbench status Progress tab (testWorkbenchControlSuite.cy.ts,
+          # testWorkbenchStatus.cy.ts) - confirmed via kubelet source diff and unfixed on
+          # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
+          # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -208,7 +208,7 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
@@ -229,7 +229,7 @@ jobs:
           # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
           # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -205,18 +205,23 @@ jobs:
 
       # ERROR: failed to create cluster: failed to pull image "docker.io/kindest/node:v1.31.6":
       #  command "docker pull docker.io/kindest/node:v1.31.6" failed with error: exit status 1
+      # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
+      # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.31.6; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # Dashboard tests fail on k8s 1.32
+          # kind v0.32.0's own default node image (its release notes recommend pinning by
+          # digest, not just tag, until node images get a different tagging scheme).
+          # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
+          # comment that turned out to be unrelated to the Kubernetes version at all (see
+          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
           # https://hub.docker.com/r/kindest/node/tags
-          # Let's keep using same version as for dashboard then
-          node_image: "docker.io/kindest/node:v1.31.6"
+          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -208,20 +208,28 @@ jobs:
       # CAUTION: must match node_image below - a drifted pre-pull is silently a no-op (see the
       # istio pre-pull's own history of this exact bug).
       - name: Pre-pull the kind image
-        run: timeout 120s bash -c 'while ! docker pull kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5; do sleep 1; done'
+        run: timeout 120s bash -c 'while ! docker pull docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998; do sleep 1; done'
 
       - name: Kubernetes KinD Cluster
         id: kind-cluster
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
-          # kind v0.32.0's own default node image (its release notes recommend pinning by
-          # digest, not just tag, until node images get a different tagging scheme).
+          # Pinned to v1.34.11 rather than kind v0.32.0's own newer default node image
+          # (v1.36.1) - kind release notes recommend pinning by digest, not just tag, until node
+          # images get a different tagging scheme, which this still does.
           # Was pinned to v1.31.6 since April 2025 over a "dashboard tests fail on k8s 1.32"
           # comment that turned out to be unrelated to the Kubernetes version at all (see
-          # components/deploy.py's "Check storage class" step and PR #77) - re-tested here.
+          # components/deploy.py's "Check storage class" step and PR #77).
+          # v1.36.1 was tried and reverted (see issue #98): Kubernetes v1.35 kubelet dropped the
+          # container name from Created/Started event messages ("Container created" instead of
+          # "Created container: <name>"), which breaks odh-dashboard's message-based oauth-proxy
+          # detection in the Workbench status Progress tab (testWorkbenchControlSuite.cy.ts,
+          # testWorkbenchStatus.cy.ts) - confirmed via kubelet source diff and unfixed on
+          # odh-dashboard main as of this writing. v1.34.11 is the latest kind image still on the
+          # pre-v1.35 kubelet message format, and matches what OpenShift 4.21 itself ships.
           # https://hub.docker.com/r/kindest/node/tags
-          node_image: "docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+          node_image: "docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998"
           cluster_name: kind
           config: components/00-kind-cluster.yaml
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ mkdir -p ~/.config/containers && printf '[machine]\nrosetta = true\n' >> ~/.conf
 
 podman machine init --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.31.6
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
 
 python3 components/deploy.py --workbench-branch=v1.36.0
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ mkdir -p ~/.config/containers && printf '[machine]\nrosetta = true\n' >> ~/.conf
 
 podman machine init --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d
 
 python3 components/deploy.py --workbench-branch=v1.36.0
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ mkdir -p ~/.config/containers && printf '[machine]\nrosetta = true\n' >> ~/.conf
 
 podman machine init --rootful --memory $((16 * 1024)) --cpus 4
 podman machine start
-kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+kind create cluster --config components/00-kind-cluster.yaml --image docker.io/kindest/node:v1.34.11@sha256:2ddcf275136744ef219498fe56ffe858f7c5c6281fa7304d6298c5c75c8a9998
 
 python3 components/deploy.py --workbench-branch=v1.36.0
 ```


### PR DESCRIPTION
## Summary

Bumps the kind cluster's `node_image` from `kindest/node:v1.31.6` to `kindest/node:v1.34.11` (digest-pinned), across all three CI workflows. Also updates the matching pre-pull step, README.md's local usage snippet, and the `run-rhoai-in-kind` skill doc - fully qualifying the image with the `docker.io/` registry prefix everywhere it appears.

**This PR originally bumped to `v1.36.1`** (kind v0.32.0's own new default node image). That version was reverted after CI (and a full local repro) found it breaks two Cypress specs - see "Update" below. `v1.34.11` is the latest kind node image that doesn't have this problem, and conveniently matches what OpenShift 4.21 itself ships as its Kubernetes version.

## Root cause (original investigation, why the bump was attempted at all)

Not a bug fix - this closes out the investigation from an earlier session into whether `node_image` (pinned since April 2025, PR-era commit aae0595, over a "dashboard tests fail on k8s 1.32" comment) could finally be updated. That investigation found the comment's real cause was an unrelated hardcoded StorageClass name (`standard-csi`) odh-dashboard's Cypress tests expected at the time - already fixed independently in #77 by removing the now-redundant `local-path-provisioner` install step. With that resolved, nothing else was found blocking a node image bump.

## Update: v1.36.1 reverted - real Kubernetes v1.35 regression, not a fixable/tunable flake

CI on the `v1.36.1` bump failed `testWorkbenchControlSuite.cy.ts` (its restart-flow test) and `testWorkbenchStatus.cy.ts`, both of which pass reliably on `main`/the old image. Full investigation is in #98. Root cause, verified directly against source rather than inferred:

- Kubernetes **v1.35** (released 2025-12-17) changed kubelet's `Created`/`Started` container-lifecycle event messages from `"Created container: <name>"`/`"Started container <name>"` to a bare `"Container created"`/`"Container started"` - the container name is dropped entirely (confirmed by diffing `pkg/kubelet/kuberuntime/kuberuntime_container.go` across k8s tags v1.28 through v1.36.1).
- odh-dashboard's Workbench-status "Progress" tab (`getNotebookEventStatus` in `notebookControllerUtils.ts`) identifies the oauth-proxy container by checking `event.message.includes('oauth-proxy')` - this can never match the new message format, so the corresponding progress steps (`Oauth proxy container created/started`, `Workbench started`) get silently dropped and stay stuck `Pending` forever.
- Confirmed this is not a timing race: raising Cypress's `defaultCommandTimeout` to 30s (3x default) didn't help, and live-driving the dashboard UI via chrome-devtools against a plain, non-restart, warm-cache workbench create reproduced the identical stuck Progress tab.
- Checked odh-dashboard's `main` branch: still broken, no upstream fix yet.
- Checked real OpenShift exposure: 4.20 (k8s 1.33) and 4.21 (k8s 1.34) are unaffected; **4.22 is already affected** (confirmed via internal CI telemetry showing real 4.22.8/4.22.9 clusters on Kubernetes v1.35.6); 5.0 (in active nightly development) tracks k8s 1.36.x and is also affected.

Rather than chase `v1.36.x` further or patch around vendored upstream test/dashboard code, re-pinned to `v1.34.11` - the latest kind node image still on the pre-v1.35 kubelet message format.

## Update 2: v1.34.11's digest pin was itself wrong - arm64-only, broke amd64 CI

CI still failed after the `v1.34.11` re-pin, but with a totally different, much earlier failure: `kind create cluster` itself failed within ~2 seconds at "Preparing nodes", with `ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"` (run 33176594968) - every matrix job failed identically, including specs that had never been touched by the v1.35 regression above.

Root cause: the digest I'd pinned (`sha256:2ddcf275...`) was captured by running `docker pull` + `docker inspect` on an **arm64 Mac** during local verification - that returns the arm64-platform-specific image digest, not the multi-arch manifest-list digest. A fully-qualified `@sha256:...` reference bypasses a registry's normal per-host platform negotiation entirely, so CI's amd64 runners were pulling and trying to boot the literal arm64 image - which explains the fast, hard failure (kind's boot-log-matching logic never sees a real amd64 systemd boot inside an arm64 container on an amd64 host).

Fixed by querying the registry v2 API directly for the tag's `Docker-Content-Digest` header (`sha256:44e222ee...`), which is the manifest-list's own digest, not either platform's individual entry - confirmed this matches what kind's own v0.31.0 release notes publish for `kindest/node:v1.34.11`. Re-verified the corrected digest pulls correctly on both arm64 (local) and resolves to the correct amd64 manifest per `docker manifest inspect`.

## Test plan

- [x] Recreated the local kind cluster with `v1.34.11`, ran `components/deploy.py` to completion, confirmed zero unhealthy pods.
- [x] Ran `testWorkbenchControlSuite.cy.ts` (both tests) and `testWorkbenchStatus.cy.ts` against the live stack - **all passing** (2/2 and 1/1) after the revert, reproducing the failure first on `v1.36.1` (3/3 failed attempts) to confirm the fix actually addresses it.
- [x] Ran `actionlint` against all three workflow files - only the same two pre-existing, unrelated findings from prior PRs.
- [x] Verified the corrected manifest-list digest resolves correctly per-platform (`docker manifest inspect` + registry v2 API `Docker-Content-Digest` header), matching kind's own published digest for this tag.
- [x] Local re-verify of the corrected digest end-to-end (recreate cluster, `deploy.py`, both cypress specs) - both `testWorkbenchControlSuite.cy.ts` (2/2) and `testWorkbenchStatus.cy.ts` (1/1) passing
- [ ] Full CI run on this PR

<details>
<summary>Trajectory (original v1.36.1 bump attempt)</summary>

1. With #77 (StorageClass workaround removal) merged, picked back up the `node_image` bump: checked kind v0.32.0's own release notes for its new default/prebuilt node images (`v1.36.1`, `v1.35.5`, `v1.34.8`, `v1.33.12`, all published with digest pins and an explicit recommendation to pin by digest rather than tag).
2. Updated all three workflow files' `node_image` and matching pre-pull `docker pull` command (kept in sync per the istio pre-pull's own prior history of drifting and silently becoming a no-op), plus README.md's local usage snippet and the `run-rhoai-in-kind` skill's documented bring-up command.
3. Verified with `actionlint` - only the two pre-existing findings, unrelated and unchanged.
4. Recreated the local kind cluster with the new image and ran `components/deploy.py` in the background - it hung on the first attempt; investigated and found several Kyverno/cert-manager pods stuck in `ImagePullBackOff`/`ContainerCreating` from real wall-clock time having passed between conversation turns (an unrelated, transient local DNS/network flake, self-healing on pod recreation - not connected to the node image version).
5. Also hit and worked around a background-process lifecycle gotcha: a bare `command &` backgrounded inside one `Bash` tool invocation doesn't survive past that invocation returning (the parent shell exits), so the process was actually still alive but appeared to "complete instantly" when waited on from a fresh shell in a later tool call - switched to the tool's own `run_in_background` mechanism, which manages the subprocess lifecycle correctly across calls.
6. `deploy.py` then hit a real failure: `argocd app sync odh-dashboard` timed out. Diagnosed via `kubectl -n argocd get applications.argoproj.io odh-dashboard -o yaml` (after first discovering `kubectl get application` resolves ambiguously between `argoproj.io` and a `app.k8s.io` CRD, both registering the plural `applications` - a new ambiguity in this node image, but purely a kubectl short-name resolution quirk, not a functional issue) - found `InvalidSpecError: error getting cluster by server "https://kubernetes.default.svc": server.secretkey is missing`, a known ArgoCD application-controller startup race. Manually logged the local `argocd` CLI into the cluster (replicating `deploy.py`'s own login sequence), terminated the stuck operation, and retried the sync directly - it succeeded once the controller had finished its own bootstrap, confirming this was a one-off timing race unrelated to the Kubernetes version (another app, `kf-pipelines`, had already synced fine in the same run).
7. Re-ran `deploy.py` fully - hit a second, more interesting failure: `Error from server (UnsupportedMediaType)` applying a JSON payload to the `imagestreams.image.openshift.io` polyfill CRD (`components/crds/imagestream.yaml`), with a strategic-merge-patch-shaped body (`$setElementOrder/tags`) that CRDs have never supported (only JSON patch, JSON merge patch, and server-side apply). Root-caused to the local `kubectl` client being six minor versions behind the new `v1.36.1` server (`v1.30.2`, beyond kubectl's supported +/-1 skew) - downloaded a current kubectl to a scratch path (declined to overwrite the system-wide `/usr/local/bin/kubectl` via `sudo`, since that's outside this task's scope) and confirmed the identical payload applies cleanly with a version-matched client.
8. Re-ran `deploy.py` fully a third time with the newer kubectl on `PATH` - completed successfully end-to-end, zero unhealthy pods afterward.
9. Re-ran the `workbenches.cy.ts` Cypress test against the healthy cluster - first attempt failed after retrying 3 times over 4m24s (full output wasn't captured that run, piped through `tail -40` which masked the real exit code via a classic pipe/`pipefail` gap); re-ran again with full output captured this time - passed cleanly in 55s, indicating the first failure was itself a local one-off flake (leftover test-project namespace or browser state from the earlier failed `deploy.py` attempts), not a real regression.
10. Reviewed the final diff (exactly the 5 intended files, no stray changes) and committed.

</details>

<details>
<summary>Trajectory (v1.36.1 CI failure investigation and revert to v1.34.11)</summary>

1. PR's own CI run showed `testWorkbenchControlSuite.cy.ts` and `testWorkbenchStatus.cy.ts` newly failing; confirmed via recent `main` runs that both pass reliably there, ruling out pre-existing flake.
2. Reproduced end-to-end locally: recreated the kind cluster with `v1.36.1`, ran `deploy.py` clean, ran the vendored `odh-dashboard` (v2.37.1-odh) cypress specs the same way CI does - identical failure, 3/3 Cypress-internal retries.
3. Ruled out plain slowness (`--config defaultCommandTimeout=30000` didn't help) and streamed live `kubectl get events` to confirm the underlying oauth-proxy container events did land correctly and promptly in the K8s API even while the dashboard showed them missing.
4. Formed and then corrected an initial hypothesis (a `notebooks.kubeflow.org/last-activity`-annotation-vs-event-timestamp race) after being asked to verify directly against odh-dashboard source rather than infer from behavior.
5. Drove the dashboard live via chrome-devtools MCP against a manually-created, non-Cypress, warm-cache, non-restart workbench and saw the identical broken Progress tab - ruled out anything restart-specific or timing-based.
6. Read the raw K8s `Event` objects directly and found the real cause: `Created`/`Started` events' `.message` field carries no container name; only `involvedObject.fieldPath` does, which the dashboard's classification logic never reads.
7. Diffed kubelet source across k8s versions to confirm exactly when (v1.35.0) and how the message format changed, and independently confirmed via internal Slack search that the vendored test's own Events-log assertions hardcode the old message format.
8. Checked real OpenShift exposure via internal Slack (k8s-rebase-bot channel + real CI job telemetry) - 4.20/4.21 unaffected, 4.22 already on the affected k8s 1.35.x, 5.0 (in active nightly dev) also affected.
9. Checked odh-dashboard `main` - confirmed the bug is still present there too, nothing to backport.
10. Re-pinned to `v1.34.11` (latest kind image on the pre-v1.35 kubelet format), fully digest-pinned with the explicit `docker.io/` qualifier throughout the repo, updated the stale "kind's own default" comment to explain the actual reasoning and link to #98.
11. Recreated the local cluster with `v1.34.11`, redeployed, and re-ran both previously-failing specs - both pass.

Full trajectory and evidence: https://github.com/jiridanek/rhoai-in-kind/issues/98

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local KinD cluster setup instructions to use Kubernetes node image v1.34.11 pinned to a verified digest.
  * Improved setup reproducibility by replacing the previous image reference.

* **Chores**
  * Updated automated KinD-based validation environments to use the same pinned node image.
  * Aligned image preloading and cluster configuration for more consistent test execution across validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


