### PR TITLE
ci: wait for ArgoCD application-controller readiness before syncing apps

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -251,6 +251,23 @@ def main():
         # fail in server mode, because argocd-server (in-pod) cannot reach its host-only
         # 127.0.0.1:6443 to validate the cluster.
 
+    with gha_log_group("Wait for ArgoCD application-controller readiness"):
+        # argocd-application-controller is a StatefulSet, not a Deployment - the "Login to
+        # ArgoCD" wait above (which only waits on Deployments) does not cover it, so its own
+        # internal bootstrap (populating argocd-secret's server.secretkey field, used to
+        # decrypt/access its in-cluster credentials cache) can still be in progress even once
+        # argocd-server is answering logins. A sync attempted before that finishes fails with
+        # "error getting cluster by server \"https://kubernetes.default.svc\": server.secretkey
+        # is missing" - confirmed in CI: the *first* app synced (kf-pipelines) usually clears
+        # this race by luck (more wall-clock time has passed by the time it runs), but the
+        # *second* one (odh-dashboard) can land squarely inside the window and burn its whole
+        # ARGOCD_TIMEOUT retrying a sync that can never succeed until this key exists.
+        sh(
+            f"""timeout {ARGOCD_TIMEOUT} bash -c '
+                while [ -z "$(kubectl -n argocd get secret argocd-secret -o jsonpath="{{.data.server\\.secretkey}}" 2>/dev/null)" ]; do sleep 1; done
+            '"""
+        )
+
     # actually needed, did something that DSP Workbenches dashboard tab won't load without
     with gha_log_group("Install KF Pipelines"):
         # dspa is looking up configmaps in this namespace


### PR DESCRIPTION
## Summary

Adds an explicit wait for `argocd-secret`'s `server.secretkey` field before `deploy.py` attempts any `argocd app sync`. Fixes a real, reproducible race that was misdiagnosed at first as a node_image-specific issue on #79, but traced back to a pre-existing gap unrelated to that bump.

## Root cause

`argocd-application-controller` is a StatefulSet, not a Deployment - the existing "Login to ArgoCD" step's readiness wait (`kubectl wait --for=condition=Available deployment --all -n argocd`) only covers Deployments, so it never actually waited on the application-controller. Its own internal bootstrap (populating `argocd-secret`'s `server.secretkey` field, used to decrypt/access its in-cluster credentials cache) can still be in progress even once `argocd-server` is already answering logins successfully.

A sync attempted before that finishes fails with `error getting cluster by server "https://kubernetes.default.svc": server.secretkey is missing`. Since the Application is never re-evaluated in that state, the existing `while ! argocd app sync ...; do sleep 1; done` retry loop just burns its whole `ARGOCD_TIMEOUT` (60s) with zero progress - each retry hits the same precondition failure.

## Evidence

Found while investigating why #79's CI was failing far more than usual. Confirmed via real CI logs: 4 of 17 ods-ci matrix jobs on that PR hit this identically -

- `kf-pipelines` (synced first) reliably clears the race, since more wall-clock time has passed by the time its sync attempt starts - its log shows a live resource table (`Role`, `ClusterRole`, ...) culminating in `Message: successfully synced (all tasks run)` within ~9 seconds.
- `odh-dashboard` (synced second, immediately after) can land squarely inside the window with no margin left - its log shows only the status table's header row and **zero resource rows for the entire 60-second window**, proof the sync command was failing the precondition check before it could even begin computing a diff, on every single retry.

This is unrelated to the node_image version bump in #79 - it's a pre-existing timing gap in `deploy.py` that a 60-second flat budget usually (but not always) survived.

## Test plan

- [x] `python3 -m py_compile components/deploy.py`
- [x] Ran `components/deploy.py` to completion end-to-end locally against a freshly created cluster with the new wait step in place - confirmed it runs between "Login to ArgoCD" and "Install KF Pipelines" in the log, and the rest of the script completes normally.
- [ ] Full CI run on this PR

<details>
<summary>Trajectory</summary>

1. On PR #79 (node_image bump), the user asked to check if CI was "failing more than usual." `gh pr checks 79` showed a much higher failure rate than the established baseline (5/23) from earlier PRs.
2. Investigated the failing jobs' failing steps: found a clean split - some failed at "Deploy stuff into Kubernetes" (all with the identical `argocd app sync odh-dashboard` timeout, exit 124), others failed later at "Run ods-ci tests" or "Run cypress" on unrelated, scattered test-specific assertions (PVC notifications, tensorboard, flask notebook, UI wizard step timing) matching this repo's known pre-existing notebook-spawn flakiness.
3. User asked whether the pattern reflected a real performance regression from different Kubernetes defaults, or general version bloat. Investigated empirically rather than guessing: created two throwaway bare kind clusters (nothing deployed) with each node image and directly compared control-plane memory/CPU, node image size, built-in API resource count, and cold/warm pod-startup latency. Found the newer image is actually *smaller*, bare `kube-apiserver` memory is nearly identical (205MB vs 201MB), and pod startup is if anything *faster* - ruling out general bloat or heavier defaults as an explanation. The one genuine "different defaults" effect (Kubernetes' built-in API surface grew from 59 to 68 resource types over 5 minor versions) was real but far too small to explain multi-minute failures.
4. User asked what could be determined from CI logs specifically. Pulled per-step timestamps for both a failing and a passing job from the *same* PR run and found total step duration didn't correlate with failure (the passing job's Deploy step actually took *longer* overall). Pulled the raw `argocd app sync` output for both `kf-pipelines` and `odh-dashboard` within the same failing job and found the exact signature described above - a live progress table for the app that succeeded, versus a bare header with no rows for the entire timeout window for the one that failed.
5. Root-caused this precisely by re-checking the earlier local reproduction of the same error: `argocd-application-controller` is a StatefulSet, confirmed via `kubectl -n argocd get secret argocd-secret -o jsonpath='{.data.server\.secretkey}'` that this is a real, populated (but sometimes-not-yet-populated) field.
6. Implemented the fix as an explicit wait step, verified the exact generated shell command directly against a live cluster before wiring it into `deploy.py`, then ran the full script end-to-end locally to confirm it doesn't disrupt normal operation and that the new step actually executes in the right place.
7. Committed on its own branch, off `origin/main` (not #79's still-open branch), keeping this fix independent and reviewable/mergeable on its own regardless of the outcome of the node_image discussion.

</details>