### PR TITLE
ci: wait for CRDs to be Established after deploying fake CRDs

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -152,6 +152,12 @@ def main():
 
     with gha_log_group("Deploy fake CRDs"):
         sh("kubectl apply -k components/crds")
+        # Establishing a CRD is asynchronous: `kubectl apply` returning just means the object was
+        # accepted, not that the API server's discovery/RESTMapper already knows the resource type.
+        # Querying too soon (e.g. the imagestreams clusterrole creation below) can 404 - confirmed
+        # in CI (~1s race window, issue #82). Wait for every CRD, not just imagestreams, since other
+        # steps later query Route/OAuthClient/DSC/DSCI from this same batch.
+        sh("kubectl wait --for=condition=Established crd --all --timeout=30s")
 
     with gha_log_group("Deploy api-extension"):
         sh("kubectl apply -k components/api-extension")


### PR DESCRIPTION
## Summary

Wait for all CRDs to reach `Established` right after "Deploy fake CRDs", before anything queries a resource type from that batch.

## Root cause

`kubectl apply` returning success only means the CRD object was accepted by the API server, not that its discovery/RESTMapper has registered the resource type yet. `deploy.py` immediately queries `imagestreams.image.openshift.io` (via `kubectl create clusterrole --resource=...` for `system:image-puller`/`cluster-monitoring-view`) right after applying the fake CRDs, and hit this ~1s race twice in PR #81's own CI run. The same batch also defines Route/OAuthClient/DSC/DSCI CRDs used later in the script (oauth-server, DSC/DSCI apply), which are exposed to the same class of race even though not yet observed failing.

## Related issue

Fixes #82

## Test plan

- [x] `python3 -c "import py_compile; py_compile.compile('components/deploy.py', doraise=True)"`
- [ ] CI

<details>
<summary>Plan</summary>

# Fix issue #82: CRD establishment races in deploy.py

## Context

`deploy.py` applies a batch of fake OpenShift CRDs at line 154 (`kubectl apply -k components/crds`) and then immediately uses resources from those CRDs without waiting for them to become Established. The API server's discovery endpoint can still 404 the resource type for ~1s after `kubectl apply` returns. Hit 2/8 jobs in PR #81's CI for `imagestreams.image.openshift.io` specifically.

## Races identified

1. **imagestreams CRD → clusterrole creation (lines 154→175/178)** — High severity, observed in CI (issue #82)
2. **Route/OAuthClient/DSC/DSCI CRDs → oauth-server & DSC creation (lines 154→400, 154→423)** — Medium severity, not yet observed but same pattern
3. **Minio deployment Available → Istio route for bucket creation (lines 231→268)** — Low severity, not observed

## Fix

**File:** `components/deploy.py`

**Change 1:** After line 154 (`sh("kubectl apply -k components/crds")`), add:
```python
sh("kubectl wait --for=condition=Established crd --all --timeout=30s")
```

This single line covers races #1 and #2 — it waits for every CRD in the cluster (including the ones just applied) to reach Established before proceeding. The `--all` selector is safe here because cert-manager, Kyverno, Istio, and Gateway API CRDs were all applied earlier and are already Established by this point; the only freshly-applied ones are from `components/crds`.

**Race #3 (Minio):** Skip for now — not observed in CI, and `create_buckets` already runs inside a deferred function after `kubectl wait --for=condition=Available` on the Minio deployment.

## Verification

- `python -c "import py_compile; py_compile.compile('components/deploy.py', doraise=True)"`
- Verify the wait is between CRD creation (line 154) and first CRD-dependent use (line 175)

</details>

<details>
<summary>Trajectory</summary>

1. Started from open issue #82 ("deploy.py: intermittent race between 'Deploy fake CRDs' and imagestreams.image.openshift.io discovery"), which was itself filed during PR #81's CI-failure triage: the imagestreams clusterrole creation at `deploy.py:175`/`178` intermittently hit `the server doesn't have a resource type "imagestreams" in group "image.openshift.io"` right after "Deploy fake CRDs" applied the CRD, because `kubectl apply` returning "created" doesn't mean the API server's discovery/RESTMapper has registered the type yet (observed gap ~0.95s passing vs ~1.07-1.5s failing).
2. Read `components/deploy.py` in full and `components/crds/` directory listing to see what other CRDs are in the same "Deploy fake CRDs" batch (`imagestream.yaml`, `route.yaml`, `oauthclient.yaml`, `dsc.yaml`, `dsci.yaml`, `buildconfig.yaml`, `consolelink.yaml`, `servicemonitor.yaml`, a Dashboard CRD).
3. Drafted an initial plan scoped only to the `imagestreams` CRD (matching the issue title exactly) and entered plan mode.
4. User pushed back before approving: "is that the only cause of the races? weren't there other races?" — asking for a broader sweep rather than a narrow single-resource fix.
5. Dispatched a general-purpose agent to systematically walk every sequential step pair in `deploy.py`, the `TestFrame.defer()`/drain pattern, and open GitHub issues, looking for any other CRD-apply-then-immediate-use or resource-created-then-immediately-relied-upon race.
6. Agent's findings: confirmed race #1 (imagestreams, issue #82); found a second plausible race (#11 in its numbering) — Route/OAuthClient/DSC/DSCI CRDs from the same `components/crds` batch are used later by the oauth-server kustomization (`deploy.py:400`) and the DSC/DSCI apply (`deploy.py:423`) without an explicit Established wait, same underlying mechanism, just not yet observed failing in CI; and a low-severity, unobserved race between Minio Deployment `Available` and Istio route readiness for the deferred `create_buckets` call. It ruled out several other candidate races (Kyverno pods vs. policies, ArgoCD install vs. login, Istio gateway vs. programmed-wait, KF Pipelines sync vs. DSPA policy, notebook-controller vs. workbench imagestream) as already correctly ordered via the FIFO `defer`/drain mechanism or existing retry loops.
7. Revised the plan to fix races #1 and #2 with one change — `kubectl wait --for=condition=Established crd --all --timeout=30s` right after the "Deploy fake CRDs" apply — reasoning that waiting on `--all` CRDs (not just imagestreams) is just as cheap and closes the whole class of race for this batch at once, since every other CRD already present in the cluster at that point (cert-manager, Kyverno, Istio, Gateway API) is already Established and the wait is a no-op for them. Left the Minio/Istio-route race out of scope since it's unobserved and already partially covered by a Deployment-Available wait.
8. Exited plan mode; user approved.
9. Implemented the one-line change (plus an explanatory comment) in `components/deploy.py`, right after `kubectl apply -k components/crds`.
10. Verified: `python3 -c "import py_compile; py_compile.compile('components/deploy.py', doraise=True)"` passed.
11. Noted that PR #81 (the ArgoCD bump this issue was originally found under) had already merged, and the local working tree was still checked out on that now-merged branch `jd-bump-argocd-3.5.1`. Stashed the working-tree change, created a fresh branch `jd-fix-imagestream-crd-race` off `origin/main`, and popped the stash back onto it so this fix isn't bundled with unrelated already-merged history.
12. Committed with message referencing `Fixes #82`, pushed, and opened this PR.

</details>
