### PR TITLE
ci: enable shallow clone for kf-pipelines and odh-dashboard repos

### DIFF
--- a/components/01-argocd/kustomization.yaml
+++ b/components/01-argocd/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - namespace.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/v3.5.1/manifests/install.yaml
   - httproute.yaml
+  - repo-secrets.yaml
 
 patches:
   - path: gittimeoutconfig.yaml

--- a/components/01-argocd/repo-secrets.yaml
+++ b/components/01-argocd/repo-secrets.yaml
@@ -1,0 +1,32 @@
+---
+# Both kf-pipelines and odh-dashboard Applications pin an exact tag (see
+# components/03-kf-pipelines.yaml / components/04-odh-dashboard.yaml), so ArgoCD never needs
+# history beyond that commit. depth is ArgoCD's shallow-clone knob (Repository.Depth,
+# https://github.com/argoproj/argo-cd/blob/v3.5.1/pkg/apis/application/v1alpha1/repository_types.go)
+# added in v3.3.0 - full clones of odh-dashboard in particular have been observed timing out
+# (5+ min git fetch) under constrained network conditions.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo-odh-dashboard
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: https://github.com/opendatahub-io/odh-dashboard.git
+  depth: "1"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo-data-science-pipelines-operator
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: repository
+stringData:
+  type: git
+  url: https://github.com/opendatahub-io/data-science-pipelines-operator.git
+  depth: "1"
+type: Opaque


### PR DESCRIPTION
## Summary

Enable ArgoCD's shallow-clone support (`depth`) for the `kf-pipelines` and `odh-dashboard` repository sources.

## Root cause

Both Applications pin an exact tag (`v2.15.1`, `v2.37.1-odh`), so the repo-server never needs history beyond that single commit — yet it was fetching the full history every time. `odh-dashboard` in particular has been observed to time out (5+ min `git fetch`) inside `argocd-repo-server` under constrained network conditions during local verification.

ArgoCD added a `depth` field on the repository Secret (`Repository.Depth`, https://github.com/argoproj/argo-cd/blob/v3.5.1/pkg/apis/application/v1alpha1/repository_types.go#L125-L126) in v3.3.0 to request a shallow clone. Sparse checkout (fetching only the Application's `source.path`, not the whole tree) is a separate, still-unimplemented ArgoCD feature (argoproj/argo-cd#11198) — not available as of v3.5.1, so this PR only covers the shallow-clone half.

## Related issue

Follow-up from the ArgoCD v3.0.6 -> v3.5.1 bump (#81); related to opendatahub-io/notebooks#1789 (same root pain — slow full clones — for a different repo/tool in this stack that has no shallow/sparse option at all).

## Test plan

- [x] `kubectl kustomize components/01-argocd` — confirms the new repo Secrets render correctly
- [x] Applied to a live kind cluster (`kubectl apply -k components/01-argocd --server-side --force-conflicts`), confirmed both `repo-odh-dashboard`/`repo-data-science-pipelines-operator` Secrets created with `depth: "1"`
- [x] Bounced `argocd-repo-server` (forcing a fresh clone cache) with `ARGOCD_REPO_SERVER_LOGLEVEL=debug`, hard-refreshed both apps, confirmed debug logs show `git fetch origin <sha> --depth 1 --force --prune` for both repos
- [x] Both `kf-pipelines` and `odh-dashboard` re-synced successfully (Synced/Healthy) after the change
- [ ] CI

<details>
<summary>Plan</summary>

# Enable shallow clone for ArgoCD-managed repositories

## Context

ArgoCD's repo-server clones the full git history of `opendatahub-io/odh-dashboard.git` and `opendatahub-io/data-science-pipelines-operator.git` before rendering manifests. The `odh-dashboard` repo in particular is large — its `git fetch` has been observed timing out (5+ min) under constrained network conditions. Both Applications pin a specific tag (`v2.37.1-odh`, `v2.15.1`), so only that single commit is needed.

ArgoCD v3.3.0+ supports a `depth` field on repository Secrets to enable shallow clone. There is no sparse-checkout support in ArgoCD as of v3.5.1 (open request argoproj/argo-cd#11198).

## Changes

**File:** `components/01-argocd/repo-secrets.yaml` (new) — repository Secrets with `depth: "1"` for both repos.

**File:** `components/01-argocd/kustomization.yaml` — add `repo-secrets.yaml` to the `resources:` list.

## Verification

- `kubectl apply -k components/01-argocd --server-side --force-conflicts --dry-run=server`
- Full `deploy.py` CI run — verify both apps sync successfully with shallow-cloned repos; check `argocd-repo-server` logs for depth-related behavior

</details>

<details>
<summary>Trajectory</summary>

1. User asked about new ArgoCD features unlocked by the v3.0.6 -> v3.5.1 bump; a background research agent surveyed release notes v3.1.0 through v3.5.1, initially citing only a couple of items. User pushed back twice ("why are you ignoring the rest of the release notes?", "you're citing 3 features, I'm sure you saw more than 3"), prompting a fuller background sweep that also (on its own initiative, resuming after a follow-up notification) surfaced a shallow-clone/depth feature thread from v3.3.0 and related v3.5.0 correctness fixes.
2. User asked specifically for "shallow _and sparse_ checkout for pipelines and dashboard" to be implemented.
3. Read `components/03-kf-pipelines.yaml` and `components/04-odh-dashboard.yaml` to confirm both Applications pin exact tags (`v2.15.1`, `v2.37.1-odh`) rather than tracking branches, which matters for whether depth=1 is safe (it only needs to resolve that one tagged commit).
4. Dispatched a research agent to determine ArgoCD's actual support surface for shallow clone and sparse checkout as of v3.5.1. It reported shallow clone via a `depth` field on the repo Secret, and confirmed sparse checkout is NOT supported (open feature request argoproj/argo-cd#11198, filed 2022, no PRs).
5. Drafted an initial plan using `depth: "1"` on new repository Secrets for both repos, added to `components/01-argocd/kustomization.yaml`.
6. User then shared https://akuity.io/blog/optimizing-gitops-at-scale-with-shallow-clones-in-argo-cd, which described the field as `shallowClone: "true"` instead of `depth: "N"` — a direct contradiction requiring verification before proceeding, since two independent sources now disagreed on the actual field name.
7. In the same turn, user also shared https://github.com/opendatahub-io/notebooks/issues/1789 (filed by the user), which reports that the `notebooks` repo itself is slow to clone and that neither ArgoCD nor Kustomize can do shallow/sparse cloning for it — confirmed as separate/out-of-scope context (that repo is fetched via `kubectl apply -k <remote>` / kustomize's own git fetch in `deploy.py`, not via an ArgoCD Application, so this PR's fix does not apply there).
8. Resolved the field-name discrepancy by going to ArgoCD's actual source: fetched `pkg/apis/application/v1alpha1/repository_types.go` at the `v3.5.1` tag via `gh api search/code` + raw GitHub fetch, and found the real field: `Depth int64 \`json:"depth,omitempty"\`` (line 125-126) — confirming the original `depth: "1"` plan was correct and the blog's `shallowClone` terminology was inaccurate/outdated.
9. Implemented `components/01-argocd/repo-secrets.yaml` with two repository Secrets (`repo-odh-dashboard`, `repo-data-science-pipelines-operator`), each `argocd.argoproj.io/secret-type: repository` labeled, `depth: "1"`, and added the new file to `components/01-argocd/kustomization.yaml`'s `resources:` list.
10. Validated via `kubectl kustomize components/01-argocd` that the secrets render with the correct `depth: "1"` field.
11. Found a live kind cluster already running (from earlier PR #81/#83 verification work) with ArgoCD v3.5.1 already installed; applied the updated kustomization directly (`kubectl apply -k components/01-argocd --server-side --force-conflicts`) and confirmed both new Secrets were created with the expected base64-encoded `depth: "1"` value.
12. Confirmed via `argocd repo list` that both repos were already known to ArgoCD with `Successful` connection status.
13. Ran `argocd app get <app> --hard-refresh` for both apps; initial repo-server log grep for "depth"/"shallow"/"clone" found no direct evidence, because the existing repo-server pod's on-disk git clone predated the `depth` setting — ArgoCD does incremental fetches on an existing local clone, so the setting might not retroactively apply without a fresh clone.
14. To force a truly fresh clone and get visibility into the exact git command used, set `ARGOCD_REPO_SERVER_LOGLEVEL=debug` on the `argocd-repo-server` Deployment (which also caused a pod restart, giving a clean `/tmp` cache), waited for rollout, then re-ran hard-refresh on both apps.
15. Grepped the resulting debug logs and found direct confirmation for both repos: `git fetch origin <sha> --depth 1 --force --prune` (odh-dashboard: ~6.9s; kf-pipelines: ~1.6s) — proof the `depth` setting is honored by the repo-server's actual fetch command.
16. Reverted the debug log-level env var change (`kubectl set env deployment/argocd-repo-server ARGOCD_REPO_SERVER_LOGLEVEL-`) since it was only needed for verification, not part of the shipped fix; waited for rollout; confirmed via `argocd app list` that both apps remained Synced/Healthy (odh-dashboard showed transient `Progressing` from the pod restarts caused by verification, not a regression).
17. Since the working tree was still checked out on the already-open PR #83 branch (`jd-fix-imagestream-crd-race`), stashed the two changed/new files, created a fresh branch `jd-argocd-shallow-clone` off `origin/main`, and popped the stash onto it so this change ships as its own independent PR.
18. Committed with an explanatory message covering the depth fix, the local verification steps, and a note on why sparse checkout was left out (unsupported by ArgoCD as of v3.5.1). Pushed (after retrying once past a transient LFS-lock-verify DNS hiccup and a mid-command model-availability blip) and opened this PR.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ArgoCD repository configuration for the ODH Dashboard and Data Science Pipelines Operator.
  * Enabled shallow Git repository cloning for faster synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->