### PR TITLE
ci: revert CRD Established wait from --all to a single named CRD

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -155,9 +155,18 @@ def main():
         # Establishing a CRD is asynchronous: `kubectl apply` returning just means the object was
         # accepted, not that the API server's discovery/RESTMapper already knows the resource type.
         # Querying too soon (e.g. the imagestreams clusterrole creation below) can 404 - confirmed
-        # in CI (~1s race window, issue #82). Wait for every CRD, not just imagestreams, since other
-        # steps later query Route/OAuthClient/DSC/DSCI from this same batch.
-        sh("kubectl wait --for=condition=Established crd --all --timeout=30s")
+        # in CI (~1s race window, issue #82).
+        #
+        # NOTE: `--all` (waiting on every CRD in the cluster) was tried here and reverted - it
+        # broke every CI run with `.status.conditions accessor error: <nil> is of the type <nil>,
+        # expected []interface{}`. A CRD just created by the `kubectl apply` above can momentarily
+        # have `.status.conditions: null` (not an empty list) before the apiextensions-apiserver
+        # controller populates it; kubectl's `--all` list-based check treats that as a fatal type
+        # error instead of retrying, unlike the single-resource watch-based wait used below, which
+        # tolerates it. Name only the CRD(s) actually queried immediately after this step -
+        # Route/OAuthClient/DSC/DSCI from this same batch aren't used until much later, with plenty
+        # of time for their own Established condition to settle.
+        sh("kubectl wait --for=condition=Established crd/imagestreams.image.openshift.io --timeout=30s")
 
     with gha_log_group("Deploy api-extension"):
         sh("kubectl apply -k components/api-extension")

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -157,16 +157,25 @@ def main():
         # Querying too soon (e.g. the imagestreams clusterrole creation below) can 404 - confirmed
         # in CI (~1s race window, issue #82).
         #
-        # NOTE: `--all` (waiting on every CRD in the cluster) was tried here and reverted - it
-        # broke every CI run with `.status.conditions accessor error: <nil> is of the type <nil>,
-        # expected []interface{}`. A CRD just created by the `kubectl apply` above can momentarily
-        # have `.status.conditions: null` (not an empty list) before the apiextensions-apiserver
-        # controller populates it; kubectl's `--all` list-based check treats that as a fatal type
-        # error instead of retrying, unlike the single-resource watch-based wait used below, which
-        # tolerates it. Name only the CRD(s) actually queried immediately after this step -
-        # Route/OAuthClient/DSC/DSCI from this same batch aren't used until much later, with plenty
-        # of time for their own Established condition to settle.
-        sh("kubectl wait --for=condition=Established crd/imagestreams.image.openshift.io --timeout=30s")
+        # A plain `kubectl wait --for=condition=Established` (with or without `--all`) is not
+        # reliable here: a CRD just created by the `kubectl apply` above can momentarily have
+        # `.status.conditions: null` (not an empty list, not an absent field) before the
+        # apiextensions-apiserver controller populates it - confirmed in CI, both with `--all` and
+        # with a single named CRD. kubectl's condition accessor treats an explicit `null` as a
+        # fatal type error (`.status.conditions accessor error: <nil> is of the type <nil>,
+        # expected []interface{}`) and exits immediately, without ever retrying via its usual
+        # watch. This is a known, still-unfixed class of bug in kubectl's condition accessor - see
+        # https://github.com/kubernetes/kubernetes/issues/66439 (closed stale, never fixed) and
+        # downstream reports of the identical message hitting the same "just-created, status not
+        # yet populated" case: https://github.com/strimzi/strimzi-kafka-operator/issues/4737,
+        # https://github.com/infinispan/infinispan-operator/issues/187. Both resolve it the same
+        # way we do here: retry/poll on the caller side instead of trusting `kubectl wait` to
+        # tolerate a not-yet-populated status. Wrap it in our own retry loop - only
+        # imagestreams.image.openshift.io is queried immediately after this step;
+        # Route/OAuthClient/DSC/DSCI from this same batch aren't used until much later, with
+        # plenty of time for their own Established condition to
+        # settle.
+        sh("timeout 30s bash -c 'until kubectl wait --for=condition=Established crd/imagestreams.image.openshift.io --timeout=5s; do sleep 1; done'")
 
     with gha_log_group("Deploy api-extension"):
         sh("kubectl apply -k components/api-extension")


### PR DESCRIPTION
## Summary

Wrap the "Deploy fake CRDs" readiness wait in a retry loop, instead of a single `kubectl wait --for=condition=Established` call (with or without `--all`).

## Root cause

#83 changed the wait to `kubectl wait --for=condition=Established crd --all --timeout=30s`, intending to also cover Route/OAuthClient/DSC/DSCI from the same batch. This broke every CI run since merge: `.status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}`.

A CRD just created by the preceding `kubectl apply -k components/crds` can momentarily have `.status.conditions` explicitly set to JSON `null` (not an empty list, not an absent field) before the apiextensions-apiserver controller populates it. kubectl's condition accessor treats an explicit `null` as a fatal type error and exits immediately - **this happens on the very first check** (confirmed in CI: ~170ms after apply), before `kubectl wait` ever gets a chance to retry/watch. Narrowing from `--all` to a single named CRD (`imagestreams.image.openshift.io`, the only one from this batch actually queried immediately afterward) was tried first and still hit the identical crash, proving this isn't about `--all`'s fan-out - it's that `kubectl wait` itself doesn't tolerate a not-yet-populated status at all, for any target.

This is a known, still-unfixed class of bug in kubectl's condition accessor - see https://github.com/kubernetes/kubernetes/issues/66439 (closed stale, never fixed) and downstream reports of the identical error message hitting the same just-created/status-not-yet-populated case: https://github.com/strimzi/strimzi-kafka-operator/issues/4737, https://github.com/infinispan/infinispan-operator/issues/187. Both resolve it the same way this PR does: retry/poll on the caller side instead of trusting `kubectl wait` to tolerate it.

## Related issue

Regression from #83 (itself fixing #82). Found while triaging CI failures on #85, which is otherwise unrelated to this bug but shares the same `deploy.py` execution path.

## Test plan

- [x] `python3 -c "import py_compile; py_compile.compile('components/deploy.py', doraise=True)"`
- [x] Verified against a live kind cluster: `kubectl apply -k components/crds` followed by `timeout 30s bash -c 'until kubectl wait --for=condition=Established crd/imagestreams.image.openshift.io --timeout=5s; do sleep 1; done'` succeeds
- [ ] CI

<details>
<summary>Plan</summary>

Small, self-contained fix - no separate plan file; see Summary/Root cause above and the commit history on this PR for how the fix evolved (single-named-CRD wait was tried first and also failed in CI, before landing on the retry-loop approach).

</details>

<details>
<summary>Trajectory</summary>

1. While monitoring CI on PR #85 (shallow-clone), the user pointed at a failed job: https://github.com/jiridanek/rhoai-in-kind/actions/runs/32898416217/job/97966286527?pr=85.
2. Used the `ci-triage` skill: `job_steps` showed the failure was in "Deploy stuff into Kubernetes", well before any ArgoCD/shallow-clone-related step.
3. Pulled the raw job log (`job_log`) and found the actual Python traceback: `subprocess.CalledProcessError` on `kubectl wait --for=condition=Established crd --all --timeout=30s` - the line added by PR #83, already merged to main, completely unrelated to PR #85's own change.
4. Grepped the log around the failure and found the real kubectl-level error just above the traceback: `error: .status.conditions accessor error: <nil> is of the type <nil>, expected []interface{}`.
5. Noticed the last "condition met" CRD printed before the crash was `xlistenersets.gateway.networking.x-k8s.io`, and diffed the full printed list against the CRDs actually applied by the repo to find which one was silently missing: `buildconfigs.build.openshift.io` (alphabetically between `backendtlspolicies` and `certificaterequests`, both present) - the CRD from `components/crds/buildconfig.yaml` that had *just* been created by the immediately preceding "Deploy fake CRDs" step.
6. Formed the hypothesis: a freshly created CRD's `.status.conditions` can be transiently `null` before the apiextensions-apiserver controller populates it, and kubectl's `wait --for=condition=X --all` (list-based, evaluating every matching object) treats a `null` conditions field as a hard type error rather than "not yet true, keep watching" - unlike the single-resource form, which I hypothesized (incorrectly, per step 10) uses a watch and is documented/widely used for exactly this CRD-readiness pattern.
7. Attempted to reproduce directly against the local kind cluster with a throwaway CRD (`testraces.example.com`); the timing window was too narrow to catch the exact null-conditions state in a manual test (the CRD's Established condition was already populated by the time the wait command ran), so treated the CI log itself as the primary evidence rather than requiring a clean local repro.
8. Checked whether the broader "wait for the whole batch" rationale from #83 was actually load-bearing: grepped `components/oauth-server/` and the rest of `components/` for any place other than `imagestreams.image.openshift.io` that queries a resource from the "Deploy fake CRDs" batch soon after it's applied. Found none used tightly - Route only appears later, in `components/10-minio/deploy.yaml`, well after "Deploy fake CRDs" with plenty of elapsed time; DSC/DSCI are applied even later. Concluded the `--all` broadening from #83 wasn't actually necessary in practice, only imagestreams has a tight race.
9. Reverted `deploy.py`'s "Deploy fake CRDs" step to wait on the single named CRD (`crd/imagestreams.image.openshift.io`) instead of `--all`, committed, pushed, and opened this PR (#86).
10. User pointed at a new CI failure on this PR itself: https://github.com/jiridanek/rhoai-in-kind/actions/runs/32901789460/job/97977081070?pr=86. Triaged again with `ci-triage`: the *exact same* `.status.conditions accessor error` crashed, but now on the single-named-CRD wait, at ~170ms after the CRD was created - disproving the step-6 hypothesis that single-resource wait tolerates a transient null via a watch. The crash happens on kubectl's very first check, before any watch/retry loop is ever reached, regardless of whether the target is `--all` or a single name.
11. User asked to find the actual upstream Kubernetes bug tracking this. Dispatched a research agent to search kubernetes/kubernetes, kubernetes/kubectl, and kubernetes/client-go issue trackers. Found no exact-match upstream ticket, but found a closely related one (kubernetes/kubernetes#66439, a different type-mismatch shape of the same "kubectl wait's condition accessor has poor error handling" class, closed stale/unfixed) plus two downstream operator repos (strimzi/strimzi-kafka-operator#4737, infinispan/infinispan-operator#187) reporting the *identical* error message for the same just-created/status-not-yet-populated scenario - both resolving it via caller-side retry rather than a kubectl fix, confirming this is a known, still-open gap rather than a one-off fluke.
12. Rewrote the fix to wrap the wait in a retry loop matching the pattern already used elsewhere in `deploy.py` for other race-prone commands: `timeout 30s bash -c 'until kubectl wait --for=condition=Established crd/imagestreams.image.openshift.io --timeout=5s; do sleep 1; done'`. Updated the code comment to cite the three issues above instead of describing the mechanism from scratch.
13. Verified the final version locally against the live kind cluster (`kubectl apply -k components/crds` then the retry-loop wait) and confirmed it succeeds.
14. Committed as a second commit on the same branch/PR (not amended, since the PR was already open and under active CI iteration) and pushed.

</details>
