### PR TITLE
ci: bump Kyverno v1.14.4 -> v1.19.0, adopt success-event visibility

### DIFF
--- a/components/02-kyverno/kustomization.yaml
+++ b/components/02-kyverno/kustomization.yaml
@@ -6,3 +6,42 @@ kind: Kustomization
 namespace: kyverno
 resources:
   - https://github.com/kyverno/kyverno/releases/download/v1.19.0/install.yaml
+
+patches:
+  - path: success-events-config.yaml
+  # install.yaml bakes in `--omitEvents=PolicyApplied,PolicySkipped` on these 3 controllers, which
+  # silently overrides the ConfigMap's generateSuccessEvents/successEventActions above (confirmed by
+  # a "generateSuccessEvents is enabled but PolicyApplied is in omitEvents" log warning otherwise).
+  # Appending a second --omitEvents wins: Kyverno v1.19.0 registers it with Go's standard
+  # flag.FlagSet.StringVar in all three controllers, so repeated values overwrite earlier ones - see
+  # https://github.com/kyverno/kyverno/blob/v1.19.0/cmd/kyverno/main.go#L397,
+  # cmd/background-controller/main.go#L146, cmd/reports-controller/main.go#L323). Appending avoids
+  # depending on the flag's position in the args array, which shifts across version bumps -
+  # cleanup-controller has no --omitEvents flag at all, so it's not patched here.
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --omitEvents=PolicySkipped
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kyverno-admission-controller
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --omitEvents=PolicySkipped
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kyverno-background-controller
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --omitEvents=PolicySkipped
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kyverno-reports-controller

--- a/components/02-kyverno/kustomization.yaml
+++ b/components/02-kyverno/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 
 namespace: kyverno
 resources:
-  - https://github.com/kyverno/kyverno/releases/download/v1.14.4/install.yaml
+  - https://github.com/kyverno/kyverno/releases/download/v1.19.0/install.yaml

--- a/components/02-kyverno/success-events-config.yaml
+++ b/components/02-kyverno/success-events-config.yaml
@@ -1,0 +1,16 @@
+---
+# https://github.com/kyverno/kyverno/pull/15466 (v1.18.0): let the ConfigMap filter *which* success
+# events the engine emits, so `kubectl get events` gives a direct answer to "did this mutate/generate
+# policy actually fire" instead of digging through pod logs or screenshots (a recurring debugging
+# pattern in this project's CI triage, e.g. the imagestream-status and dspa-pipelinestore policies).
+# generateSuccessEvents is the master switch (off by default); successEventActions narrows it to just
+# the two action kinds this project's policies produce - see
+# https://github.com/kyverno/kyverno/blob/v1.19.0/pkg/event/action.go for the full action list.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kyverno
+  namespace: kyverno
+data:
+  generateSuccessEvents: "true"
+  successEventActions: "Resource Mutated,Resource Generated"


### PR DESCRIPTION
## Summary

Bump Kyverno from v1.14.4 to v1.19.0 (commit 1), and adopt the `successEventActions` config knob to surface mutate/generate policy-fire visibility via `kubectl get events` (commit 2).

## Root cause / motivation

`components/02-kyverno/kustomization.yaml` was pinned to v1.14.4, five minor releases behind. No breaking changes affect this project's usage: `kyverno.io/v1`/`kyverno.io/v2beta1` `ClusterPolicy` with `mutate`/`generate`/`foreach`/JMESPath is untouched across v1.15.0-v1.19.0. Two fixes are directly relevant to problems this project has repeatedly hit:
- v1.19.0 #15754 "policy status retry on conflict" - the same class of readiness-race this project has fought piecemeal (issues #82, #83/#86), now affecting `oc wait --for=condition=Ready clusterpolicy`.
- v1.18.0 #15437 "ForEachGeneration downstream accumulation fix" - relevant to this project's `mutate.foreach`/generate policies.

New in v1.19.0 (kyverno/kyverno#16868): `kubectl apply` of any legacy `ClusterPolicy` now prints an admission deprecation warning. No removal version is committed yet; existing policies keep working unchanged, just noisier CI logs. A follow-up (CEL migration) is being scoped separately - see below.

Commit 2 adopts `generateSuccessEvents`/`successEventActions` (kyverno/kyverno#15466, v1.18.0) so `kubectl get events` can directly answer "did this policy fire" - a debugging pattern this project has hit repeatedly (imagestream-status, dspa-pipelinestore policies). Also had to override a baked-in `--omitEvents=PolicyApplied,PolicySkipped` controller flag that otherwise silently re-suppresses these events regardless of the ConfigMap setting.

## Related issue

Not tied to a specific issue; a proactive dependency bump plus adopting a debugging-visibility feature discovered while surveying the changelog.

## Test plan

- [x] `kubectl kustomize components/02-kyverno` - manifest resolves cleanly
- [x] Applied to a live kind cluster: all 4 Kyverno controllers (admission/background/cleanup/reports) roll out to v1.19.0 successfully
- [x] All 8 project `ClusterPolicy` resources re-applied and reach `Ready`
- [x] Confirmed `--omitEvents` override takes effect (`omitEvents=PolicySkipped` in controller startup logs, not the baked-in `PolicyApplied,PolicySkipped`)
- [x] Triggered a generate policy (namespace creation) and confirmed `kubectl get events -A --field-selector reason=PolicyApplied` shows `clusterpolicy/sync-ca-configmap ... resource generated` and `clusterpolicy/openshift-like-sa-cm ... resource generated`
- [ ] CI

<details>
<summary>Plan</summary>

# Bump Kyverno v1.14.4 -> v1.19.0, then adopt success-event visibility

## Context

`components/02-kyverno/kustomization.yaml` pins Kyverno's install manifest to v1.14.4, five minor releases behind current (v1.19.0). A changelog survey (v1.15.0 through v1.19.0) found no breaking changes affecting this project's usage - `kyverno.io/v1`/`kyverno.io/v2beta1` `ClusterPolicy` with `mutate`/`generate`/`foreach`/JMESPath is untouched; the new CEL-based policy types (`ValidatingPolicy`, `MutatingPolicy`, etc.) live in a separate `policies.kyverno.io` API group and are purely additive.

Two fixes are directly relevant to problems this project has repeatedly hit:
- **v1.19.0 #15754** "policy status retry on conflict" - fixes a race where a status-update conflict could leave a ClusterPolicy stuck without `Ready=True`. `deploy.py` relies on `oc wait --for=condition=Ready clusterpolicy --all` / `clusterpolicy/<name>` (e.g. the `force-dspa-pipelinestore-database` policy, PR #70) - this is the same class of readiness-race this project has been fixing piecemeal (issues #82, #83/#86).
- **v1.18.0 #15437** "ForEachGeneration downstream accumulation fix" - this project's `notebook-routes-policy.yaml`/`pipelines-routes-policy.yaml` are `v2beta1` policies using generate + mutate rules with preconditions.

Also relevant, already confirmed safe: no policy here uses HTTP-based `context` (only a JMESPath `variable` in `policy.yaml`), so the v1.18 HTTP context blocklist (later relaxed in v1.19) doesn't apply.

**Watch item, not a blocker:** install.yaml now bundles many more CRDs (namespaced CEL policy variants, OpenReports, etc.), increasing apiserver/controller memory footprint slightly on the resource-constrained local kind cluster - confirmed acceptable during verification.

**New in v1.19.0, confirmed via kyverno/kyverno#16868:** `kubectl apply` of any legacy `ClusterPolicy`/`Policy`/`Clean(up)Policy` now returns an admission warning. No removal version is committed yet - this project's `ClusterPolicy` resources keep working unchanged, but every `kubectl apply` in CI will now print this warning. Full migration to the new CEL-based policy types is a separate, much larger effort tracked as a follow-up.

## Commit 1: version bump

**File:** `components/02-kyverno/kustomization.yaml` - bump the `install.yaml` URL from `v1.14.4` to `v1.19.0`.

## Commit 2: adopt `successEventActions` for policy-fire visibility

v1.18.0 added a `successEventActions` Kyverno ConfigMap parameter (kyverno/kyverno#15466) that controls which success-path Kubernetes Events the engine emits - currently success events are suppressed by default. Turning this on makes `kubectl get events` show a concrete "policy X mutated/generated resource Y" trail, with no policy-YAML changes needed.

**Files:** `components/02-kyverno/success-events-config.yaml` (new ConfigMap patch) + `components/02-kyverno/kustomization.yaml` (wire it in, plus `--omitEvents` override patches discovered necessary during verification).

## Verification

- `kubectl kustomize components/02-kyverno`
- Full local `deploy.py` run / live kind cluster verification of Kyverno readiness and policy firing

</details>

<details>
<summary>Trajectory</summary>

1. User asked to plan a Kyverno version update and asked what's relevant in the changelog. Surveyed v1.15.0 through v1.19.0 release notes via a research agent, cross-checked against this project's actual policy usage (`kyverno.io/v1`/`v2beta1` ClusterPolicy with mutate/generate/foreach/JMESPath, no CEL policies, no HTTP context calls).
2. Confirmed no breaking changes apply; identified two directly-relevant fixes (policy-status-retry-on-conflict in v1.19.0, ForEachGeneration accumulation fix in v1.18.0) and one new deprecation-warning behavior in v1.19.0 (verified against the actual upstream PR kyverno/kyverno#16868 rather than trusting an initial overclaim about a "v1.20 removal" - the PR only says "a future release", not a committed version).
3. User asked to evaluate adoptable *features* (not just bug fixes) for a second commit, mirroring the earlier ArgoCD PR pattern. A second research pass surfaced `generateSuccessEvents`/`successEventActions` (v1.18.0) as directly relevant to this project's repeated "did the policy actually fire" debugging pain.
4. Wrote and got approval for a plan: commit 1 = version bump, commit 2 = adopt `successEventActions`.
5. Implemented commit 1 (kustomization.yaml URL bump), verified via `kubectl kustomize` and, once the local kind cluster was back up (podman machine had stopped, restarted per prior convention), applied it live and confirmed all 4 controllers rolled out to v1.19.0 and all 8 ClusterPolicy resources reached Ready. Also confirmed the new v1.19.0 admission deprecation warning fires exactly as expected on `kubectl apply` of each policy.
6. Implemented commit 2 (ConfigMap patch for `generateSuccessEvents`/`successEventActions`), verified the kustomize patch merges additively into the existing `kyverno` ConfigMap without disturbing other keys.
7. Live-verified commit 2 and found it *didn't* work as expected: no events appeared. Found via pod logs an explicit warning: "generateSuccessEvents is enabled but PolicyApplied is in omitEvents - no success events will be generated" - install.yaml bakes `--omitEvents=PolicyApplied,PolicySkipped` into 3 controller Deployments (admission/background/reports; cleanup-controller has no such flag), which independently overrides the ConfigMap setting.
8. Initially computed exact array indices for the `--omitEvents` arg in each of the 3 deployments to write index-based JSON6902 patches, but the user suggested a more robust alternative: append a second `--omitEvents=` flag at the end of the args list instead, relying on "last flag wins" parsing semantics - avoiding any dependency on the arg's position, which shifts across Kyverno version bumps.
9. Dispatched a research agent to verify Kyverno's actual flag registration (`cmd/kyverno/main.go`, `cmd/background-controller/main.go`, `cmd/reports-controller/main.go` at the v1.19.0 tag) - confirmed `--omitEvents` is a plain `pflag.StringVar` (last-occurrence-wins), not an accumulating `StringSlice`/`StringArray` type, so the append approach is semantically correct.
9. In parallel, the user flagged a real CI failure on `main` (https://github.com/jiridanek/rhoai-in-kind/actions/runs/32934024455/job/98071696511) reporting "kyverno failed to come up". Triaged via the `ci-triage` skill and the `logs.py`-collected `events.k8s.io`/core event dumps: found the `kyverno-admission-controller` pod stuck at `Pulling image "reg.kyverno.io/kyverno/kyvernopre:v1.14.4"` for the full 120s wait window, while the other 3 controllers started normally in the same run - confirmed as a transient image-pull flake against `reg.kyverno.io` unrelated to any pending change (main is still on v1.14.4; this bump hadn't merged), not a regression. User agreed to move on without filing an issue.
10. Implemented the append-based `--omitEvents=PolicySkipped` JSON6902 patches for the 3 affected deployments, verified the rendered manifest shows both the original and appended flag, applied live, and confirmed via controller startup logs that the effective value is now `PolicySkipped` only (i.e., `PolicyApplied` is no longer omitted).
11. Re-triggered the generate policies and confirmed `kubectl get events -A --field-selector reason=PolicyApplied` now shows real "resource generated" events for `sync-ca-configmap` and `openshift-like-sa-cm` - the events land on the cluster-scoped `ClusterPolicy` object itself (hence appearing under the `default` namespace), not the target namespace.
12. Re-applied all 5 policy files on top of v1.19.0 and confirmed all 8 `ClusterPolicy` resources still reach `Ready`.
13. Split the working-tree changes into the two planned commits (had to reconstruct commit 1 as a standalone single-line diff before restoring the full patches section for commit 2, since both had been edited together in the working tree), pushed, and opened this PR.
14. User separately requested a third commit to fix all deprecation warnings (migrate every `ClusterPolicy` to the new CEL-based policy types). That is being scoped as a follow-up - initial review of the actual policy YAML (generate+clone+synchronize, mutate with patchStrategicMerge/JSON6902, foreach-over-arrays, JMESPath preconditions/functions like `time_now_utc()`/`split()`) shows meaningfully more complexity than initially assumed, and CEL-based `GeneratingPolicy`/`MutatingPolicy` maturity for `generate`-style clone/sync semantics needs to be confirmed before committing to a migration plan. Not included in this PR.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded Kyverno to version 1.19.0.
  - Added success-event reporting for resource mutation and generation actions.
  - Kyverno now omits routine “PolicySkipped” events, reducing unnecessary event noise.

- **Improvements**
  - Applied the updated event behavior consistently across admission, background, and reporting controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->