### PR TITLE
ci: fix CEL-migration regression: GeneratingPolicy operations narrowed to CREATE-only

### DIFF
--- a/components/02-kyverno/notebook-routes-policy.yaml
+++ b/components/02-kyverno/notebook-routes-policy.yaml
@@ -1,7 +1,19 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyverno-route-tlsroute-manager
+  # NOTE: pipelines-routes-policy.yaml defines its own, differently-scoped
+  # kyverno-pipeline-route-manager ClusterRole under a distinct name. These two files used
+  # to define a ClusterRole with the SAME name ("kyverno-route-tlsroute-manager") but
+  # different, non-overlapping rule sets - `kubectl apply` on either file silently clobbered
+  # the other's RBAC grants (no merging across files for a same-named cluster-scoped object),
+  # since a ClusterRole isn't a Kustomize/Kyverno concept, just a plain resource whose whole
+  # object gets replaced by the last apply. Confirmed live in #95's investigation: this caused
+  # kyverno-background-controller to lose "get/create destinationrules"/"get/create httproutes"
+  # permissions whenever notebook-routes-policy.yaml was applied after pipelines-routes-policy.yaml,
+  # breaking DSPA's DestinationRule/HTTPRoute generation with "... is forbidden: User
+  # \"system:serviceaccount:kyverno:kyverno-background-controller\" cannot get resource ...".
+  # Distinct names per file avoid the collision entirely.
+  name: kyverno-notebook-route-manager
 rules:
   - apiGroups:
       - gateway.networking.k8s.io
@@ -39,11 +51,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kyverno-bind-route-tlsroute-manager
+  name: kyverno-bind-notebook-route-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kyverno-route-tlsroute-manager
+  name: kyverno-notebook-route-manager
 subjects:
   - kind: ServiceAccount
     name: kyverno-admission-controller
@@ -74,9 +86,18 @@ spec:
       enabled: true
   matchConstraints:
     resourceRules:
+      # UPDATE is required, not just CREATE: the companion update-route-host-for-notebook
+      # MutatingPolicy below always fires an UPDATE on the Route right after DSPO/the notebook
+      # controller creates it (to set spec.host, since the Route is created with an empty
+      # host). With synchronize: true and only CREATE listed here, Kyverno's background
+      # controller re-evaluates this GeneratingPolicy's match on that very next UPDATE event,
+      # decides its own trigger "no longer matches" (operations: ["CREATE"] doesn't cover
+      # UPDATE), and immediately deletes the TLSRoute it just generated - permanently, since
+      # no further CREATE ever happens for that Route. Confirmed live: without "UPDATE" here,
+      # the TLSRoute is generated then torn down within the same second, every time.
       - apiGroups: ["route.openshift.io"]
         apiVersions: ["v1"]
-        operations: ["CREATE"]
+        operations: ["CREATE", "UPDATE"]
         resources: ["routes"]
   matchConditions:
     - name: has-notebook-owner

--- a/components/02-kyverno/pipelines-routes-policy.yaml
+++ b/components/02-kyverno/pipelines-routes-policy.yaml
@@ -1,7 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kyverno-route-tlsroute-manager
+  # NOTE: notebook-routes-policy.yaml defines its own kyverno-notebook-route-manager
+  # ClusterRole under a distinct name - see the comment there for why (#95): this file and
+  # that one used to share the name "kyverno-route-tlsroute-manager" with different rule
+  # sets, and whichever was applied last silently clobbered the other's RBAC grants.
+  name: kyverno-pipeline-route-manager
 rules:
   - apiGroups:
       - gateway.networking.k8s.io
@@ -63,11 +67,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kyverno-bind-route-tlsroute-manager-pipelines
+  name: kyverno-bind-pipeline-route-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kyverno-route-tlsroute-manager
+  name: kyverno-pipeline-route-manager
 subjects:
   - kind: ServiceAccount
     name: kyverno-admission-controller
@@ -97,9 +101,17 @@ spec:
       enabled: true
   matchConstraints:
     resourceRules:
+      # UPDATE is required, not just CREATE (see the matching comment on
+      # generate-httproute-for-pipeline below, and issue #95): DSPO re-applies/patches its
+      # owned Services during normal reconciliation shortly after creating them. With
+      # synchronize: true and only CREATE listed here, that very next UPDATE makes Kyverno's
+      # background controller decide this policy's trigger "no longer matches" and delete the
+      # DestinationRule it just generated - permanently, since no further CREATE ever happens
+      # for that Service. Confirmed live: without a DestinationRule, mTLS from the gateway to
+      # the pipelines API server fails, breaking Elyra pipeline submission entirely.
       - apiGroups: [""]
         apiVersions: ["v1"]
-        operations: ["CREATE"]
+        operations: ["CREATE", "UPDATE"]
         resources: ["services"]
   matchConditions:
     - name: has-dspa-owner
@@ -152,9 +164,21 @@ spec:
       enabled: true
   matchConstraints:
     resourceRules:
+      # UPDATE is required, not just CREATE (root cause of #95's Elyra pipeline-submission
+      # failure): the update-route-host-for-pipeline MutatingPolicy below always fires an
+      # UPDATE on the Route right after DSPO creates it (to set spec.host, since DSPO creates
+      # the Route with an empty host). With synchronize: true and only CREATE listed here,
+      # Kyverno's background controller re-evaluates this GeneratingPolicy's match on that very
+      # next UPDATE event, decides its own trigger "no longer matches" (operations: ["CREATE"]
+      # doesn't cover UPDATE), and immediately deletes the HTTPRoute it just generated -
+      # permanently, since no further CREATE ever happens for that Route. Confirmed live: the
+      # HTTPRoute is generated then torn down within the same second, every time, leaving the
+      # pipelines API server completely unroutable (any request 404s at the gateway) - which is
+      # what actually broke Elyra's kfp.Client() in #95, not the URL's missing "/pipeline"
+      # suffix that its error message misleadingly suggests.
       - apiGroups: ["route.openshift.io"]
         apiVersions: ["v1"]
-        operations: ["CREATE"]
+        operations: ["CREATE", "UPDATE"]
         resources: ["routes"]
   matchConditions:
     - name: has-dspa-owner

--- a/components/02-kyverno/policy.yaml
+++ b/components/02-kyverno/policy.yaml
@@ -20,9 +20,23 @@ spec:
       enabled: true
   matchConstraints:
     resourceRules:
+      # UPDATE is required, not just CREATE (found alongside #95's root cause; this policy
+      # was in scope of the same CEL-migration regression, PR #88): the propagate-ca-injection-label
+      # MutatingPolicy below always fires an UPDATE on any Namespace that ods-ci/the Dashboard
+      # labels opendatahub.io/dashboard=true, shortly after it's created. With synchronize:
+      # true and only CREATE listed here, that UPDATE makes Kyverno's background controller
+      # decide this policy's trigger "no longer matches" and delete the ConfigMap it just
+      # generated. Confirmed live via kyverno-background-controller logs ("trigger no longer
+      # matches the policy, deleting downstream resources"). Unlike the Route-triggered
+      # policies in pipelines-routes-policy.yaml/notebook-routes-policy.yaml (which never
+      # recover, since nothing ever re-CREATEs a Route), this one's generateExisting: true
+      # periodically re-scans all namespaces and regenerates the ConfigMap - so the practical
+      # symptom here was a transient flap/race rather than a permanent loss, previously
+      # (mis)diagnosed as a generic "boot race" (see the commit marking this ConfigMap's volume
+      # source `optional: true` in openshift-like-volume-mounts below).
       - apiGroups: [""]
         apiVersions: ["v1"]
-        operations: ["CREATE"]
+        operations: ["CREATE", "UPDATE"]
         resources: ["namespaces"]
   variables:
     - name: nsName

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -232,6 +232,22 @@ def main():
         with tf:
             pass
 
+    with gha_log_group("Restart Kyverno background-controller to pick up CRDs installed after it started"):
+        # kyverno-background-controller (unlike admission-controller, see kustomization.yaml's
+        # --crdWatcher=true patch) has no CRD-watcher informer at all in v1.19.0 - its RESTMapper
+        # (pkg/utils/restmapper.GetRESTMapper) is a memory-cached discovery client built once, at
+        # leader-election time, right after the pod starts (~line 82 above). Gateway API's
+        # HTTPRoute/TLSRoute CRDs aren't installed until "Install Istio" (~line 120), well after
+        # that first discovery snapshot. Confirmed live in CI (PR #96 follow-up): every
+        # generate-httproute-for-pipeline/generate-tlsroute-for-notebook run then fails with
+        # "failed to map gvk to gvr gateway.networking.k8s.io/v1, Kind=HTTPRoute (no matches for
+        # kind ...)", which - combined with synchronize:true - permanently deletes the generated
+        # route on the very next reconcile (see PR #96 / issue #95). Restarting the deployment here,
+        # after every CRD this repo's policies generate/watch has been installed, forces a fresh
+        # RESTMapper on the next leader-election.
+        sh("kubectl -n kyverno rollout restart deployment/kyverno-background-controller")
+        sh("kubectl -n kyverno rollout status deployment/kyverno-background-controller --timeout=120s")
+
     with gha_log_group("Install Kyverno policies"):
         sh("timeout 30s bash -c 'while ! kubectl apply -f components/02-kyverno/policy.yaml; do sleep 1; done'")
         sh("timeout 30s bash -c 'while ! kubectl apply -f components/02-kyverno/notebook-routes-policy.yaml; do sleep 1; done'")


### PR DESCRIPTION
## Summary

Fixes the Elyra pipeline-submission failure in #95, and a related latent race previously misdiagnosed as a "boot race" in #89: PR #88's Kyverno CEL migration silently narrowed several `GeneratingPolicy` resources from implicitly matching **all** admission operations (the legacy `ClusterPolicy` engine's default when `operations` isn't specified) to matching **`CREATE` only** — breaking every one of them that has `synchronize: true` and a resource that gets updated shortly after creation.

## Root cause

**This is a regression introduced by the CEL migration (PR #88), not a pre-existing bug carried forward.**

The legacy `kyverno.io/v2beta1 ClusterPolicy` rules (`generate-tlsroute-for-notebook`, `generate-backendtls-for-service`, `sync-ca-configmap`, from PR #30) used `match.any.resources.kinds: [...]` with **no `operations:` key at all**. Kyverno's legacy admission-matching engine defaults to matching all operations (CREATE, UPDATE, DELETE, CONNECT) when unspecified — so these rules kept matching (and thus kept their generated resources in sync) through any subsequent UPDATE to their trigger object.

The new `policies.kyverno.io/v1` API *requires* an explicit `operations` list in `matchConstraints` — there's no implicit "match everything". When I rewrote these rules for the CEL migration (PR #88), I wrote `operations: ["CREATE"]`, silently narrowing "matches all operations" down to "CREATE only". Tellingly, in that same commit the *paired* `MutatingPolicy` rules (`update-route-host-for-pipeline`, `update-route-host-for-notebook`) correctly got `operations: ["CREATE", "UPDATE"]` — I just didn't carry that same reasoning over to the `GeneratingPolicy` side, where `synchronize: true` makes "which operations still count as a match" just as load-bearing as it is for Mutate.

**Mechanism:** with `synchronize: true`, Kyverno's background controller re-evaluates a GeneratingPolicy's match on every subsequent change to its trigger object. When an UPDATE's operation isn't in the declared `operations` list, the background controller logs `"trigger no longer matches the policy, deleting downstream resources"` and deletes the resource it just generated.

- **`generate-httproute-for-pipeline`, `generate-backendtls-for-service`** (`pipelines-routes-policy.yaml`) and **`generate-tlsroute-for-notebook`** (`notebook-routes-policy.yaml`): the paired `update-route-host-for-*` MutatingPolicy always fires an UPDATE on the same Route right after creation (to set `spec.host`, since the Route is created with an empty host). Since nothing ever re-CREATEs that Route, the generated HTTPRoute/DestinationRule/TLSRoute is gone **permanently** — this is what actually broke Elyra's `kfp.Client()` in #95 (not the URL's misleading "/pipeline" suffix its generic exception handler suggests).
- **`sync-ca-configmap`** (`policy.yaml`): `propagate-ca-injection-label`'s MutatingPolicy fires an UPDATE on any Namespace labeled `opendatahub.io/dashboard=true` shortly after creation. Same delete-on-mismatch fires, but this policy's `generateExisting: true` periodically rescans all namespaces and regenerates the ConfigMap — so the symptom here was a **transient flap/race**, not permanent loss, which is why a previous investigation (issue #89) attributed it to a generic "boot race" and worked around it by marking the ConfigMap's volume source `optional: true` rather than finding this root cause.

**Bonus bug found while verifying the fix:** `pipelines-routes-policy.yaml` and `notebook-routes-policy.yaml` both defined a `ClusterRole` named `kyverno-route-tlsroute-manager` with different, non-overlapping rule sets. `kubectl apply` on a cluster-scoped object replaces the whole object (no merging across files), so whichever file was applied last silently dropped the other's RBAC grants (`destinationrules`/`httproutes`), causing `kyverno-background-controller` to fail with `"... is forbidden: cannot get resource destinationrules/httproutes"`. Renamed to distinct `kyverno-pipeline-route-manager` / `kyverno-notebook-route-manager` per file.

## Related issue

Fixes #95. Also relevant to #89 (the "boot race" workaround there was masking this same regression for `sync-ca-configmap`).

## Test plan

- [x] Reproduced live on local kind cluster: fresh DSPA + notebook pod, ran `kfp.Client()` inside the pod exactly as Elyra's `kfp_processor.py` does — reproduced `TimeoutError: Failed getting healthz endpoint after 5 attempts` (underlying `404`, no HTTPRoute existed) before the fix
- [x] Confirmed via `kyverno-background-controller` logs: `"trigger no longer matches the policy, deleting downstream resources"` fired immediately after each Route CREATE (and after each Namespace UPDATE, for `sync-ca-configmap`)
- [x] Diffed the legacy `ClusterPolicy` (PR #30) against the CEL rewrite (PR #88) to confirm the `operations` narrowing was introduced by the migration, not carried forward
- [x] Patched policies live, confirmed HTTPRoute/DestinationRule/ConfigMap persisted after the companion MutatingPolicy's UPDATE
- [x] Applied the fix to source YAML with explanatory comments; caught and fixed the ClusterRole name collision this surfaced
- [x] Full clean end-to-end verification in a brand-new namespace (fresh DSPA, fresh Secret, fresh Notebook, no manual patching): HTTPRoute + DestinationRule generated and persisted correctly, `kfp.Client()` initialized, `get_kfp_healthz()` returned `{'multi_user': False, 'pipeline_store': 'database'}`
- [x] Verified `sync-ca-configmap` fix in a fresh namespace: ConfigMap persisted stably for 8+ seconds after the labeling UPDATE, with no further "no longer matches" log lines
- [ ] CI: `0502__ide_elyra.robot [sanity]` and `[tier1]` pass

<details>
<summary>Plan</summary>

# Fix Elyra pipeline submission — workbench pod TLS trust (issue #95)

## Context

PR #91 fixed CA-trust for DSPO's own pods (#89) and label-scoping (#90). Both Elyra tests still fail on main tip (run 33008813248). The `kfp.Client()` "did you mean /pipeline" error is a **red herring** — Elyra's `kfp_processor.py` uses a bare `except Exception` that unconditionally suggests `/pipeline` regardless of actual cause. Every historical occurrence (RHODS-12780, Slack threads) was TLS cert trust, not URL path. See issue #95 comments for full debunking.

The real cause: the **workbench pod** (Elyra notebook) can't verify the pipeline API server's TLS cert when submitting a pipeline.

## Current CA injection chain (PR #91)

1. `sync-ca-configmap` — copies `odh-trusted-ca-bundle` ConfigMap to ALL namespaces
2. `propagate-ca-injection-label` — when NS gets `opendatahub.io/dashboard=true`, adds `rhoai-in-kind.io/inject-openshift-ca=true`
3. `openshift-like-volume-mounts` — on Pod CREATE in labeled namespaces, injects projected volume (with `odh-trusted-ca-bundle` as optional source) + `SSL_CERT_FILE` env var

This chain *should* work for workbench pods IF the namespace is labeled before the pod is created. But it hasn't been confirmed — the workbench pod was already deleted before cluster-logs were collected in CI.

## Plan: reproduce locally and diagnose

### Step 1 — Verify the mutation on the local kind cluster

Deploy a DSPA + notebook in a test namespace and inspect the workbench pod before it gets torn down.

### Step 2 — Identify the gap

Possible failure modes: namespace not labeled in time, policy doesn't match the pod, `SSL_CERT_FILE` not respected by Elyra, or the volume mount replacing the SA token mount breaks something.

### Step 3 — Fix based on diagnosis

Once root cause is confirmed, fix will likely be a small adjustment to the existing Kyverno policies.

*(Note: live reproduction disproved the TLS-trust hypothesis this plan was built around, and later converged on a much more specific root cause than "diagnosis" implied — a GeneratingPolicy `operations` gap introduced by the CEL migration, not a namespace-labeling timing issue. See Trajectory below.)*

</details>

<details>
<summary>Trajectory</summary>

1. Confirmed both `0502__ide_elyra.robot [sanity]` and `[tier1]` still fail on main tip (run 33008813248, commit 9541795c — PR #91 merge) with `Element 'xpath=//a[.="Run Details."]' did not appear in 30 seconds`, same symptom as before PR #91.

2. Re-examined the "/pipeline suffix" theory from issue #95's own body: fetched `elyra-ai/elyra`'s `kfp_processor.py` source directly (`elyra/pipeline/kfp/kfp_processor.py:195-220`), confirmed the tip text is unconditionally appended by a bare `except Exception` wrapper whenever the endpoint path isn't literally `/pipeline` — not diagnostic of anything specific, regardless of the actual underlying exception.

3. Re-examined an earlier correction already posted on the issue (TLS/cert trust, based on Jira RHODS-12780 + several Slack threads reporting the identical error text historically traced to `ssl.SSLCertVerificationError`). Live-reproduced by creating a test namespace (`elyra-test`), labeling it `opendatahub.io/dashboard=true`, and creating a bare Notebook CR. Confirmed via `kubectl exec`:
   - `SSL_CERT_FILE=/var/run/secrets/kubernetes.io/serviceaccount/combined-ca-bundle.crt` correctly injected by the `openshift-like-volume-mounts` MutatingPolicy
   - `PIPELINES_SSL_SA_CERTS=/etc/pki/tls/custom-certs/ca-bundle.crt` correctly injected by the notebook controller's own `workbench-trusted-ca-bundle` mechanism
   - The mounted CA bundle (`workbench-trusted-ca-bundle` ConfigMap) does include "My Cluster CA" (161 certs total, verified via `openssl pkcs7 -print_certs`)
   - Checked the exact pinned component versions to rule out an env-var-name mismatch: `odh-elyra==4.2.4` (the version in workbench image `v1.36.0`, per `pyproject.toml` at that tag) reads `PIPELINES_SSL_SA_CERTS` (no `KF_` prefix) in its `kfp_authentication.py` — matching what notebook-controller `v1.10.0-5` sets. The upstream env-var rename to `KF_PIPELINES_SSL_SA_CERTS` (RHOAIENG-18582 / opendatahub-io/kubeflow#704) landed on `main` after these pinned versions and doesn't apply here.
   - Both TLS theories debunked; posted the correction to the issue with full source citations.

4. With the user's explicit go-ahead (this required copying local kind-cluster minio dev credentials into a new Secret — confirmed via `AskUserQuestion` before proceeding, per this repo's credential-use discipline), deployed a real DSPA in the test namespace.

5. Installed `python3` + `pip install kfp` directly inside the running workbench pod (`microdnf install python3 python3-pip`), and wrote a script replicating exactly what Elyra's `kfp_processor.py` does: read the mounted `odh_dsp.json` runtime config, read the pod's own ServiceAccount token, call `kfp.Client(host=..., existing_token=..., ssl_ca_cert=...)`.

6. First reproduction: `TimeoutError: Failed getting healthz endpoint after 5 attempts`, with the underlying exception being `kfp_server_api.exceptions.ApiException: (404)`. Manually curled the same endpoint with `--cacert`: `SSL certificate verify ok` (TLS was never the problem), but `istio-envoy` returned a bare 404 — meaning routing, not TLS, was broken.

7. `kubectl get httproute -n elyra-test` returned nothing, despite the DSPA being fully `Ready`. Checked `kyverno-background-controller` logs and found repeated `"trigger no longer matches the policy, deleting downstream resources"` entries for `generate-httproute-for-pipeline` and `generate-tlsroute-for-notebook`, each firing within the same second as the corresponding Route CREATE.

8. Root-caused via log correlation: `generate-httproute-for-pipeline`'s `matchConstraints.operations: ["CREATE"]` doesn't cover the `update-route-host-for-pipeline` MutatingPolicy's immediate follow-up UPDATE (setting `spec.host`, since the Route is created with an empty host by DSPO). With `synchronize: true`, Kyverno's background controller re-evaluates the match on that UPDATE, decides the trigger "no longer matches" (its declared operations don't include UPDATE), and deletes the just-generated HTTPRoute.

9. Verified live: `kubectl patch generatingpolicy generate-httproute-for-pipeline` to add `"UPDATE"` to `operations`, deleted+recreated the Route — HTTPRoute persisted this time (confirmed via `kubectl get httproute` immediately and a few seconds later). Re-ran the kfp reproduction script: got past the 404, but hit `400 Client sent an HTTP request to an HTTPS server` — no DestinationRule existed either, same CREATE-only bug in `generate-backendtls-for-service` (also observed the same "trigger no longer matches" churn for it in the background-controller logs on Service updates). Patched that policy too — DestinationRule appeared, and the `kfp.Client()` reproduction script succeeded end to end, printing `{'multi_user': False, 'pipeline_store': 'database'}` from `get_kfp_healthz()`.

10. Applied the fix properly to the source YAML files (`pipelines-routes-policy.yaml`, `notebook-routes-policy.yaml`) with explanatory comments documenting the failure mode, plus the equivalent fix to `generate-tlsroute-for-notebook` (same MutatingPolicy-pairing pattern, proactively fixed even though not directly implicated in #95's specific symptom, since the same bug class applies).

11. Re-applying the fixed YAML files via `kubectl apply -f` (rather than the earlier live `kubectl patch`) surfaced a second, independent bug: `kyverno-background-controller` started failing with `"... is forbidden: cannot get resource destinationrules/httproutes"`. Root-caused via `kubectl get clusterrole kyverno-route-tlsroute-manager -o yaml` diffing against both source files: `pipelines-routes-policy.yaml` and `notebook-routes-policy.yaml` each defined a `ClusterRole` with the identical name `kyverno-route-tlsroute-manager` but different, non-overlapping rule sets (only the pipelines version granted `destinationrules`/`httproutes`). Whichever file's `kubectl apply` ran last silently replaced the whole object, dropping the other file's grants. Fixed by renaming to distinct per-file names (`kyverno-pipeline-route-manager`, `kyverno-notebook-route-manager`) with their own bindings.

12. Ran a full clean end-to-end verification in a brand-new namespace (`elyra-final`) with no manual policy patching — just the fixed YAML applied normally: DSPA reached `Ready`, HTTPRoute + DestinationRule were generated and persisted correctly on the first try, a fresh Notebook picked up the `elyra-dsp-details` volume mount once the DSPA's `ds-pipeline-config` Secret existed, and the `kfp.Client()` reproduction script succeeded, confirming the fix holds from a clean state.

13. Posted the full corrected root-cause analysis as a comment on #95, and opened this PR.

14. **User pushed back**, relaying a finding from a separate prior session (investigating issue #89's CA-trust race) that the Elyra tests "used to pass before the Kyverno CEL migration" and asked whether the migration (PR #88) was done wrong. Dispatched a subagent to scan that prior session's transcript: confirmed it had bisected real CI runs to find the last-green commit immediately before PR #88's merge and the first-red commit being PR #88's merge itself, but for a *different* policy (`openshift-like-volume-mounts`, the CA-mounting MutatingPolicy) — that session concluded the *policy logic itself* was byte-identical across the migration and attributed the regression to an unproven "timing race" side-effect of PR #88's other changes (Kyverno readiness-wait semantics, `--crdWatcher=true`).

15. Verified independently for the *actual* routing GeneratingPolicies at issue here: `git show <PR#30 commit>:components/02-kyverno/pipelines-routes-policy.yaml` showed the legacy `ClusterPolicy` used `match.any.resources.kinds: [...]` with no `operations:` key — Kyverno's legacy engine defaults to matching all operations when unspecified. `git show <PR#88 merge commit>:components/02-kyverno/pipelines-routes-policy.yaml` showed the CEL rewrite explicitly set `operations: ["CREATE"]` for the two `GeneratingPolicy` rules, while correctly setting `operations: ["CREATE", "UPDATE"]` for the paired `MutatingPolicy` rule in the very same commit. This proves the CEL migration itself introduced the narrowing — not a pre-existing bug, and not merely a timing shift.

16. Given this confirmed mechanism, checked whether the same gap existed elsewhere in `components/02-kyverno/`: found `sync-ca-configmap` (`policy.yaml`) had the identical `operations: ["CREATE"]` + `synchronize: true` shape, paired with `propagate-ca-injection-label`'s Namespace UPDATE. Live-reproduced: created a test namespace, labeled it, confirmed via background-controller logs that `sync-ca-configmap`'s trigger was declared "no longer matching" on the labeling UPDATE and its ConfigMap deleted — but then observed the ConfigMap persisted/reappeared within seconds, unlike the permanently-lost Route case. Attributed this to `generateExisting: true`'s periodic rescan masking the same regression as a transient flap rather than permanent loss — which is very likely what the #89 investigation's "boot race" workaround (marking the ConfigMap's volume source `optional: true`) was actually band-aiding, rather than a genuine startup-ordering race.

17. Checked the sibling `openshift-like-sa-cm` GeneratingPolicy (also `operations: ["CREATE"]` only, also Namespace-triggered) — confirmed it does *not* have `synchronize: true` enabled, so it isn't subject to the same delete-on-mismatch behavior (no evidence of "no longer matches" log lines for it); left unchanged.

18. Fixed `sync-ca-configmap` to `operations: ["CREATE", "UPDATE"]` with an explanatory comment, verified live in a fresh namespace that the ConfigMap now persists stably (8+ seconds, no further "no longer matches" log lines) after the labeling UPDATE, committed, and pushed as a second commit on this PR.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic TLSRoute and HTTPRoute generation when Routes or related resources are updated.
  * Fixed synchronization of CA configuration when Namespaces change.
  * Prevented stale controller discovery from blocking Gateway API resource processing.

* **Deployment**
  * The Kyverno background controller now restarts and waits for readiness during deployment to recognize newly installed Gateway API resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->