### PR TITLE
ci: pass ArgoCD admin password via stdin, not argv

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -327,11 +327,16 @@ def main():
         # rather than core mode: core mode's ephemeral repo-server port-forward is fragile under
         # load (mux: server closed). https://github.com/jiridanek/rhoai-in-kind/issues/40
         # `set +x` in the inner shell keeps the admin password out of the `set -x` trace.
+        # Feed the password on stdin instead of argv: `argocd login` (v3.2.0+; #23520) falls
+        # back to reading the password from stdin when `--password` is omitted and stdin is
+        # not a TTY. `printf '%s\n'` (bash builtin, no argv-visible child process) guarantees
+        # the trailing newline PromptPassword expects.
         sh(
             f"""timeout {ARGOCD_LOGIN_TIMEOUT} bash -c '
                 set +x
                 pw=$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{{.data.password}}" | base64 --decode)
-                while ! argocd login argocd.apps.127.0.0.1.sslip.io --username admin --password "$pw" --grpc-web --insecure; do sleep 2; done
+                while ! printf "%s\\n" "$pw" | argocd login argocd.apps.127.0.0.1.sslip.io --username admin \
+                        --grpc-web --insecure; do sleep 2; done
             '"""
         )
         # No `argocd cluster add` needed: every Application targets the in-cluster endpoint


### PR DESCRIPTION
## Summary

`components/deploy.py` passed the ArgoCD admin password to `argocd login` via `--password`, exposing it through `/proc/<pid>/cmdline` / `ps` for the lifetime of the process, even with `set +x` suppressing it from the shell trace.

ArgoCD v3.2.0+ (argoproj/argo-cd#23520) falls back to reading the password from stdin when `--password` is omitted and stdin is not a TTY. This change pipes the password through `printf` instead.

Verified against the v3.5.1 CLI source: `argocd login` has no `--password-stdin` flag; `PromptPassword` (`util/cli/cli.go`) reads stdin via `bufio` when `terminal.ReadPassword` fails because stdin is not a TTY, which is why the password is fed as `printf "%s\n" "$pw"`.

Fixes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ArgoCD login security by preventing the administrator password from appearing in command-line arguments.
  - Preserved existing retry behavior and login options while securely supplying credentials through standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->