### PR TITLE
ci: add actionlint workflow, fix its two existing findings

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,26 @@
+name: actionlint
+
+on:
+  pull_request:
+  # only main: a same-repo branch PR otherwise triggers this twice (push + pull_request). See #46
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
+      - name: Download actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
+++ b/.github/workflows/rhoai-in-kind-with-odh-tests-shiftleft.yaml
@@ -134,5 +134,5 @@ jobs:
         uses: actions/upload-artifact@v7
         if: "steps.collect-logs.outputs.debug_bundle_dir != '' && !cancelled()"
         with:
-          name: cluster-logs-${{ steps.artifact-name.outputs.artifact-name }}
+          name: cluster-logs-${{ matrix.workbench_branch }}
           path: ${{ steps.collect-logs.outputs.debug_bundle_dir }}

--- a/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
+++ b/.github/workflows/rhoai-in-kind-with-ods-ci.yaml
@@ -245,8 +245,7 @@ jobs:
           curl -LO "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"
           
           # Verify the kubectl binary against the checksum
-          echo "$(cat kubectl.sha256) kubectl" | sha256sum --check
-          if [ $? -ne 0 ]; then
+          if ! echo "$(cat kubectl.sha256) kubectl" | sha256sum --check; then
             echo "Checksum validation failed!"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/actionlint.yaml`, which runs `actionlint` against every workflow file on each PR/push to main (and manually via `workflow_dispatch`), using the tool's official download script. Fixes the two pre-existing lint findings that `actionlint` had been flagging (previously only caught by manually running it ad hoc), in a separate commit.

## Root cause

- `rhoai-in-kind-with-ods-ci.yaml`: `sha256sum --check`'s exit code was checked indirectly via `$?` (shellcheck SC2181) instead of directly in the `if`.
- `rhoai-in-kind-with-odh-tests-shiftleft.yaml`: the `cluster-logs` artifact name referenced `steps.artifact-name.outputs.artifact-name` — a copy-paste leftover from `rhoai-in-kind-with-ods-ci.yaml`, which does compute that output (it needs a unique name per `test_case` in its matrix). This workflow has no such step and no such matrix axis, so the reference was always dead; `actionlint` catches it as an undefined property access. Replaced with `matrix.workbench_branch`, which is real here.

## Test plan

- [x] `actionlint .github/workflows/*.yaml` — exits 0 after both fixes (previously exit 1 with exactly these two findings).
- [ ] New `actionlint` workflow runs and passes on this PR (CI).