### PR TITLE
ci: instrument deploy.py with OpenTelemetry (Logfire) tracing

### DIFF
--- a/components/deploy.py
+++ b/components/deploy.py
@@ -9,7 +9,9 @@ import sys
 import textwrap
 
 import logfire
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter as GrpcOTLPSpanExporter
 from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 import certs
 
@@ -64,17 +66,49 @@ def argocd_sync_cmd(app: str) -> str:
     )
 
 
-def main():
+def _grpc_otlp_span_processor() -> BatchSpanProcessor | None:
+    # logfire.configure() auto-adds its own OTLP exporter whenever OTEL_EXPORTER_OTLP_ENDPOINT
+    # is set, but that exporter is hardcoded to HTTP/protobuf - it silently ignores
+    # OTEL_EXPORTER_OTLP_PROTOCOL=grpc (confirmed against logfire._internal.config source).
+    # IntelliJ's bundled OTel collector only speaks gRPC, so build the gRPC exporter ourselves
+    # and register it via additional_span_processors instead of letting logfire's own
+    # env-based detection wire up the (here, incompatible) HTTP one.
+    if os.environ.get("OTEL_EXPORTER_OTLP_PROTOCOL") != "grpc":
+        return None
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT")
+    if not endpoint:
+        return None
+    return BatchSpanProcessor(GrpcOTLPSpanExporter(endpoint=endpoint))
+
+
+def configure_tracing():
     # console tree locally for progress visibility; GHA's own ::group:: folding covers that
     # in CI, so the console tree would just be redundant/noisy there. OTLP export (independent
     # of both) is handled by the SDK itself via OTEL_EXPORTER_OTLP_ENDPOINT, if set.
-    logfire.configure(
-        service_name="rhoai-deploy-script",
-        send_to_logfire=False,
-        # console expects None (default on) or False - not a plain bool.
-        console=None if "CI" not in os.environ else False,
-    )
+    grpc_processor = _grpc_otlp_span_processor()
+    # Hide the endpoint from logfire's own auto-detection so it doesn't also add its
+    # (incompatible, for grpc) HTTP exporter on top of ours.
+    saved_otlp_endpoint = os.environ.pop("OTEL_EXPORTER_OTLP_ENDPOINT", None) if grpc_processor else None
+    saved_otlp_traces_endpoint = os.environ.pop("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", None) if grpc_processor else None
+    try:
+        logfire.configure(
+            service_name="rhoai-deploy-script",
+            send_to_logfire=False,
+            # console expects None (default on) or False - not a plain bool.
+            console=None if "CI" not in os.environ else False,
+            additional_span_processors=[grpc_processor] if grpc_processor else None,
+        )
+    finally:
+        if saved_otlp_endpoint is not None:
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = saved_otlp_endpoint
+        if saved_otlp_traces_endpoint is not None:
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = saved_otlp_traces_endpoint
+
     BotocoreInstrumentor().instrument()
+
+
+def main():
+    configure_tracing()
 
     tf = TestFrame()
 

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -109,18 +109,12 @@ def configure_tracing():
 
 def main():
     configure_tracing()
-
-    # One root span for the whole run, so all the gha_log_group/sh spans below nest under a
-    # single trace instead of each step showing up as its own separate top-level trace.
-    # Entered/exited manually (not `with`) to avoid re-indenting the entire function body.
-    run_span = logfire.span("deploy.py run")
-    run_span.__enter__()
-    try:
-        _main()
-    finally:
-        run_span.__exit__(*sys.exc_info())
+    _main()
 
 
+# One root span for the whole run, so all the gha_log_group/sh spans below nest under a
+# single trace instead of each step showing up as its own separate top-level trace.
+@logfire.instrument("deploy.py run")
 def _main():
     tf = TestFrame()
 

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -109,14 +109,6 @@ def configure_tracing():
 
 def main():
     configure_tracing()
-    _main()
-
-
-# One root span for the whole run, so all the gha_log_group/sh spans below nest under a
-# single trace instead of each step showing up as its own separate top-level trace.
-@logfire.instrument("deploy.py run")
-def _main():
-    tf = TestFrame()
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -126,7 +118,16 @@ def _main():
         required=not os.environ.get("WORKBENCH_BRANCH"),
     )
     args = parser.parse_args()
-    workbench_branch = args.workbench_branch
+
+    deploy(args.workbench_branch)
+
+
+# One root span for the whole run, so all the gha_log_group/sh spans below nest under a
+# single trace instead of each step showing up as its own separate top-level trace.
+# {workbench_branch=} in the span name records the argument as a span attribute too.
+@logfire.instrument("deploy.py run {workbench_branch=}")
+def deploy(workbench_branch: str):
+    tf = TestFrame()
 
     # slow to deploy so do it first
     with gha_log_group("Install Kyverno"):

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -96,6 +96,11 @@ def configure_tracing():
             inspect_arguments=True,
             sampling=None,
             send_to_logfire=False,
+            # Global, not just for sh()'s cmd attribute (see its WARNING comment): logfire's
+            # default scrubber would otherwise redact any attribute across every span - not just
+            # cmd - whose value merely looks secret-like (e.g. matches "password", "token").
+            # Accepted for the same reason as that WARNING: disposable local kind-cluster/CI
+            # credentials only, never production secrets.
             scrubbing=False,
             # console expects None (default on) or False - not a plain bool.
             console=None if "CI" not in os.environ else False,

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -122,21 +122,13 @@ def main():
     deploy(args.workbench_branch)
 
 
+# One root span for the whole run, so all the gha_log_group/sh spans below nest under a
+# single trace instead of each step showing up as its own separate top-level trace.
+# extract_args=True (the default) already records workbench_branch as a span attribute -
+# the span name itself can't be made dynamic this way (it's fixed once at decoration time),
+# but the argument is visible in the span's attributes either way.
+@logfire.instrument("deploy.py run")
 def deploy(workbench_branch: str):
-    # One root span for the whole run, so all the gha_log_group/sh spans below nest under a
-    # single trace instead of each step showing up as its own separate top-level trace.
-    # `{workbench_branch=}` only expands into logfire's own "message" attribute, not the
-    # literal OTel span name that generic viewers (e.g. the Aspire dashboard) display - so
-    # _span_name is set explicitly, pre-formatted, to make the branch show up there too.
-    with logfire.span(
-        "deploy.py run {workbench_branch=}",
-        _span_name=f"deploy.py run workbench_branch={workbench_branch}",
-        workbench_branch=workbench_branch,
-    ):
-        _deploy(workbench_branch)
-
-
-def _deploy(workbench_branch: str):
     tf = TestFrame()
 
     # slow to deploy so do it first

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -93,7 +93,10 @@ def configure_tracing():
     try:
         logfire.configure(
             service_name="rhoai-deploy-script",
+            inspect_arguments=True,
+            sampling=None,
             send_to_logfire=False,
+            scrubbing=False,
             # console expects None (default on) or False - not a plain bool.
             console=None if "CI" not in os.environ else False,
             additional_span_processors=[grpc_processor] if grpc_processor else None,
@@ -124,10 +127,8 @@ def main():
 
 # One root span for the whole run, so all the gha_log_group/sh spans below nest under a
 # single trace instead of each step showing up as its own separate top-level trace.
-# extract_args=True (the default) already records workbench_branch as a span attribute -
-# the span name itself can't be made dynamic this way (it's fixed once at decoration time),
-# but the argument is visible in the span's attributes either way.
-@logfire.instrument("deploy.py run")
+# {workbench_branch=} in the span name records the argument as a span attribute too.
+@logfire.instrument("deploy.py run {workbench_branch}")
 def deploy(workbench_branch: str):
     tf = TestFrame()
 

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -122,11 +122,21 @@ def main():
     deploy(args.workbench_branch)
 
 
-# One root span for the whole run, so all the gha_log_group/sh spans below nest under a
-# single trace instead of each step showing up as its own separate top-level trace.
-# {workbench_branch=} in the span name records the argument as a span attribute too.
-@logfire.instrument("deploy.py run {workbench_branch=}")
 def deploy(workbench_branch: str):
+    # One root span for the whole run, so all the gha_log_group/sh spans below nest under a
+    # single trace instead of each step showing up as its own separate top-level trace.
+    # `{workbench_branch=}` only expands into logfire's own "message" attribute, not the
+    # literal OTel span name that generic viewers (e.g. the Aspire dashboard) display - so
+    # _span_name is set explicitly, pre-formatted, to make the branch show up there too.
+    with logfire.span(
+        "deploy.py run {workbench_branch=}",
+        _span_name=f"deploy.py run workbench_branch={workbench_branch}",
+        workbench_branch=workbench_branch,
+    ):
+        _deploy(workbench_branch)
+
+
+def _deploy(workbench_branch: str):
     tf = TestFrame()
 
     # slow to deploy so do it first

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -8,6 +8,9 @@ import pathlib
 import sys
 import textwrap
 
+import logfire
+from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+
 import certs
 
 # rhoai_in_kind lives in ../src; put it on the path so this script runs under a
@@ -62,6 +65,17 @@ def argocd_sync_cmd(app: str) -> str:
 
 
 def main():
+    # console tree locally for progress visibility; GHA's own ::group:: folding covers that
+    # in CI, so the console tree would just be redundant/noisy there. OTLP export (independent
+    # of both) is handled by the SDK itself via OTEL_EXPORTER_OTLP_ENDPOINT, if set.
+    logfire.configure(
+        service_name="rhoai-deploy-script",
+        send_to_logfire=False,
+        # console expects None (default on) or False - not a plain bool.
+        console=None if "CI" not in os.environ else False,
+    )
+    BotocoreInstrumentor().instrument()
+
     tf = TestFrame()
 
     parser = argparse.ArgumentParser()

--- a/components/deploy.py
+++ b/components/deploy.py
@@ -110,6 +110,18 @@ def configure_tracing():
 def main():
     configure_tracing()
 
+    # One root span for the whole run, so all the gha_log_group/sh spans below nest under a
+    # single trace instead of each step showing up as its own separate top-level trace.
+    # Entered/exited manually (not `with`) to avoid re-indenting the entire function body.
+    run_span = logfire.span("deploy.py run")
+    run_span.__enter__()
+    try:
+        _main()
+    finally:
+        run_span.__exit__(*sys.exc_info())
+
+
+def _main():
     tf = TestFrame()
 
     parser = argparse.ArgumentParser()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,23 @@
 name = "rhoai-in-kind"
 version = "0.1.0"
 description = "Runs OpenShift AI Workbenches in GitHub Actions"
-requires-python = ">=3.13, <3.14"
+requires-python = ">=3.14, <3.15"
 dependencies = [
     "boto3",  # used by deploy.py create_buckets() to provision MinIO/S3 buckets
     "logfire",  # OpenTelemetry tracing for deploy.py's steps/shell commands
-    "opentelemetry-exporter-otlp-proto-grpc>=1.44.0",  # OTEL_EXPORTER_OTLP_PROTOCOL=grpc: logfire's own exporter is HTTP-only
+    "opentelemetry-exporter-otlp-proto-grpc",  # OTEL_EXPORTER_OTLP_PROTOCOL=grpc: logfire's own exporter is HTTP-only
     "opentelemetry-instrumentation-botocore",  # logfire has no built-in boto3/botocore instrumentor
 ]
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "inline-snapshot"
+]
+
+[tool.pytest]
+addopts = ["--strict-markers"]
+required_plugins = ["inline-snapshot"]
+testpaths = ["src"]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Runs OpenShift AI Workbenches in GitHub Actions"
 requires-python = ">=3.13, <3.14"
 dependencies = [
     "boto3",  # used by deploy.py create_buckets() to provision MinIO/S3 buckets
+    "logfire",  # OpenTelemetry tracing for deploy.py's steps/shell commands
+    "opentelemetry-instrumentation-botocore",  # logfire has no built-in boto3/botocore instrumentor
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.13, <3.14"
 dependencies = [
     "boto3",  # used by deploy.py create_buckets() to provision MinIO/S3 buckets
     "logfire",  # OpenTelemetry tracing for deploy.py's steps/shell commands
+    "opentelemetry-exporter-otlp-proto-grpc>=1.44.0",  # OTEL_EXPORTER_OTLP_PROTOCOL=grpc: logfire's own exporter is HTTP-only
     "opentelemetry-instrumentation-botocore",  # logfire has no built-in boto3/botocore instrumentor
 ]
 

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -77,7 +77,8 @@ def _span(
 def sh(
     cmd: str, env: dict[str, str] | None = None,
     input: str | None = None,
-    **kwargs
+    capture_output: bool = False,
+    timeout: float|None = None
 ) -> subprocess.CompletedProcess[str]:
     """Runs a shell command."""
     # No-op without a configured provider (logfire.configure() is only called by entrypoint
@@ -88,7 +89,8 @@ def sh(
     # kind-cluster/CI credentials, never production secrets.
     with _span(t"sh {cmd}"):
         env = env or {}
-        print(f"$ {cmd}", file=sys.stdout)
+        if capture_output:
+            print(f"$ {cmd}", file=sys.stdout)
         sys.stdout.flush()
         completed_process = subprocess.run(
             f"set -Eeuxo pipefail; {cmd}",
@@ -98,7 +100,8 @@ def sh(
             input=input,
             check=True,
             text=True,
-            **kwargs,
+            capture_output=capture_output,
+            timeout=timeout,
         )
         sys.stdout.flush()
         return completed_process

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -56,12 +56,17 @@ def code(depth: int) -> dict[str, Any]:
 
 
 @contextlib.contextmanager
-def span(
+def _span(
     t: Template,
 ) -> Generator[None, None, None]:
-    """Creates a span.
+    """Creates a span, attributing it to its caller's call site rather than this function's.
+
     _span_name is pre-formatted (not the raw "{cmd}" template) so generic OTel viewers
     (e.g., the Aspire dashboard), which display the literal span name, show the real command.
+
+    Private: code(4) assumes exactly one level of wrapping between the real call site and
+    this generator (contextmanager frame, this frame, the wrapper's `with` line, the wrapper's
+    caller) - true for sh()'s current single call below, but wrong if called any other way.
     """
     _span_name=f(t)
     msg_template, attributes = format_t_string(t)
@@ -81,8 +86,9 @@ def sh(
     # directly in it (not fetched at runtime inside a nested `bash -c`) leaks into the trace
     # backend. This is accepted: this repo only ever handles disposable local
     # kind-cluster/CI credentials, never production secrets.
-    with span(t"sh {cmd}"):
+    with _span(t"sh {cmd}"):
         env = env or {}
+        print(f"$ {cmd}", file=sys.stdout)
         sys.stdout.flush()
         completed_process = subprocess.run(
             f"set -Eeuxo pipefail; {cmd}",

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -26,7 +26,9 @@ def sh(
     # directly in it (not fetched at runtime inside a nested `bash -c`) leaks into the trace
     # backend. This is accepted: this repo only ever handles disposable local
     # kind-cluster/CI credentials, never production secrets.
-    with logfire.span("sh {cmd}", cmd=cmd):
+    # _span_name is pre-formatted (not the raw "{cmd}" template) so generic OTel viewers
+    # (e.g. the Aspire dashboard), which display the literal span name, show the real command.
+    with logfire.span("sh {cmd}", _span_name=f"sh {cmd}", cmd=cmd):
         env = env or {}
         print(f"$ {cmd}", file=sys.stdout)
         sys.stdout.flush()

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -22,7 +22,11 @@ def sh(
     """Runs a shell command."""
     # No-op without a configured provider (logfire.configure() is only called by entrypoint
     # scripts like deploy.py), so this is safe to leave unconditional here.
-    with logfire.span("sh {cmd}", cmd=cmd[:120]):
+    # WARNING: the full cmd string is recorded as a span attribute, so any secret embedded
+    # directly in it (not fetched at runtime inside a nested `bash -c`) leaks into the trace
+    # backend. This is accepted: this repo only ever handles disposable local
+    # kind-cluster/CI credentials, never production secrets.
+    with logfire.span("sh {cmd}", cmd=cmd):
         env = env or {}
         print(f"$ {cmd}", file=sys.stdout)
         sys.stdout.flush()

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -6,12 +6,67 @@ import os
 import subprocess
 import sys
 import time
+from string.templatelib import Template, Interpolation, convert
 from typing import TYPE_CHECKING, Generator
 
 import logfire
 
 if TYPE_CHECKING:
     from typing import Any, Callable
+
+
+def f(template: Template) -> str:
+    """Renders a t-string exactly like an f-string."""
+    parts = []
+
+    for item in template:
+        match item:
+            case str(text):
+                parts.append(text)
+
+            case Interpolation(value, _, conversion, format_spec):
+                assert conversion in ("r", "s", "a") or conversion is None, f"Unsupported conversion: {conversion}"
+                transformed = convert(value, conversion)
+                formatted = format(transformed, format_spec) if format_spec else str(transformed)
+                parts.append(formatted)
+
+    return "".join(parts)
+
+
+def format_t_string(t: Template) -> tuple[str, dict[str, Any]]:
+    template = []
+    attributes = {}
+    for v in t:
+        match v:
+            case str(text):
+                template.append(text)
+            case Interpolation(value, expression, _, _):
+                template.append(f"{{{expression}}}")
+                attributes[expression] = value
+    return "".join(template), attributes
+
+
+def code(depth: int) -> dict[str, Any]:
+    caller_frame = sys._getframe(depth)
+    return {
+        "code.filepath": caller_frame.f_code.co_filename,
+        "code.lineno": caller_frame.f_lineno,
+        "code.function": caller_frame.f_code.co_name,
+    }
+
+
+@contextlib.contextmanager
+def span(
+    t: Template,
+) -> Generator[None, None, None]:
+    """Creates a span.
+    _span_name is pre-formatted (not the raw "{cmd}" template) so generic OTel viewers
+    (e.g., the Aspire dashboard), which display the literal span name, show the real command.
+    """
+    _span_name=f(t)
+    msg_template, attributes = format_t_string(t)
+    with logfire.span(msg_template, _span_name=_span_name, **attributes, **code(4)):
+        yield
 
 
 def sh(
@@ -26,11 +81,8 @@ def sh(
     # directly in it (not fetched at runtime inside a nested `bash -c`) leaks into the trace
     # backend. This is accepted: this repo only ever handles disposable local
     # kind-cluster/CI credentials, never production secrets.
-    # _span_name is pre-formatted (not the raw "{cmd}" template) so generic OTel viewers
-    # (e.g. the Aspire dashboard), which display the literal span name, show the real command.
-    with logfire.span("sh {cmd}", _span_name=f"sh {cmd}", cmd=cmd):
+    with span(t"sh {cmd}"):
         env = env or {}
-        print(f"$ {cmd}", file=sys.stdout)
         sys.stdout.flush()
         completed_process = subprocess.run(
             f"set -Eeuxo pipefail; {cmd}",

--- a/src/rhoai_in_kind/__init__.py
+++ b/src/rhoai_in_kind/__init__.py
@@ -8,6 +8,8 @@ import sys
 import time
 from typing import TYPE_CHECKING, Generator
 
+import logfire
+
 if TYPE_CHECKING:
     from typing import Any, Callable
 
@@ -18,21 +20,24 @@ def sh(
     **kwargs
 ) -> subprocess.CompletedProcess[str]:
     """Runs a shell command."""
-    env = env or {}
-    print(f"$ {cmd}", file=sys.stdout)
-    sys.stdout.flush()
-    completed_process = subprocess.run(
-        f"set -Eeuxo pipefail; {cmd}",
-        shell=True,
-        executable="/bin/bash",
-        env={**os.environ, **env},
-        input=input,
-        check=True,
-        text=True,
-        **kwargs,
-    )
-    sys.stdout.flush()
-    return completed_process
+    # No-op without a configured provider (logfire.configure() is only called by entrypoint
+    # scripts like deploy.py), so this is safe to leave unconditional here.
+    with logfire.span("sh {cmd}", cmd=cmd[:120]):
+        env = env or {}
+        print(f"$ {cmd}", file=sys.stdout)
+        sys.stdout.flush()
+        completed_process = subprocess.run(
+            f"set -Eeuxo pipefail; {cmd}",
+            shell=True,
+            executable="/bin/bash",
+            env={**os.environ, **env},
+            input=input,
+            check=True,
+            text=True,
+            **kwargs,
+        )
+        sys.stdout.flush()
+        return completed_process
 
 
 def create_resource(resource: str):
@@ -88,13 +93,14 @@ def wait_for_webhook_service_endpoint(namespace: str):
 @contextlib.contextmanager
 def gha_log_group(title: str) -> Generator[None, Any, None]:
     """Prints the starting and ending magic strings for GitHub Actions line group in log."""
-    print(f"::group::{title}", file=sys.stdout)
-    sys.stdout.flush()
-    try:
-        yield
-    finally:
-        print("::endgroup::", file=sys.stdout)
+    with logfire.span(title):
+        print(f"::group::{title}", file=sys.stdout)
         sys.stdout.flush()
+        try:
+            yield
+        finally:
+            print("::endgroup::", file=sys.stdout)
+            sys.stdout.flush()
 
 
 class TestFrame:

--- a/src/rhoai_in_kind/test__init__.py
+++ b/src/rhoai_in_kind/test__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from . import format_t_string
+
+def test_t_string():
+    name = "n"
+    assert format_t_string(t"Hello, {name}!") == ("Hello, {name}!", {"name": "n"})
+    assert format_t_string(t"Hello, {name=}!") == ("Hello, name={name}!", {"name": "n"})


### PR DESCRIPTION
## Summary

Instruments `components/deploy.py`'s steps (`gha_log_group`) and shell commands (`sh()`) with
OpenTelemetry spans via Pydantic Logfire, giving a waterfall trace of the whole deploy run when
pointed at a local OTLP collector (e.g. the .NET Aspire dashboard) - useful for debugging which
step/command is slow or hanging, on top of GitHub Actions' `::group::` log folding which stays
untouched for CI.

## Related issue

None - exploratory tooling improvement.

## Test plan

- [x] `python -m py_compile` on `components/deploy.py` and `src/rhoai_in_kind/__init__.py`
- [x] Verified locally against a real OTLP receiver: console span tree renders correctly with
      `CI` unset, is suppressed with `CI` set (GHA's own `::group::` folding covers that case)
- [x] Verified gRPC OTLP export path (IntelliJ's bundled collector is gRPC-only; Logfire's own
      exporter is HTTP-only, confirmed by reading its source) against a real listener
- [x] Verified root span nesting: all `gha_log_group`/`sh()` spans nest under one
      `deploy.py run` span instead of appearing as separate top-level traces
- [x] `sh()`'s span records the actual command as its span name/attribute; confirmed via raw
      OTel span export capture, not just the pretty console renderer
- [ ] Full end-to-end `deploy.py` run against a live kind cluster with tracing enabled (CI)

<details>
<summary>Plan</summary>

Instrument `components/deploy.py` and its shared helpers in `src/rhoai_in_kind/__init__.py`
with OpenTelemetry tracing via Pydantic Logfire:

1. Add `logfire`, `opentelemetry-exporter-otlp-proto-grpc`, and
   `opentelemetry-instrumentation-botocore` as dependencies.
2. Wrap `gha_log_group` and `sh()` in OTel spans so every deploy step and shell command becomes
   traceable, nested under one root span per `deploy()` run.
3. Support three independent output channels: GHA `::group::` markers (always on, harmless
   outside CI), a local console span tree (on when `CI` is unset), and OTLP export (only when
   `OTEL_EXPORTER_OTLP_ENDPOINT` is set) - since Logfire's own exporter is HTTP-only, build a
   gRPC exporter manually when `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` is requested.
4. Make span names show real values (command text, workbench branch) in generic OTel viewers
   like the Aspire dashboard, not just Logfire's own pretty console renderer - this requires
   pre-formatting `_span_name` rather than relying on `{var}` template expansion, which only
   populates Logfire's internal "message" attribute.
5. Address code-review findings: restore an accidentally-dropped stdout echo for
   `capture_output=True` calls, document a fragile frame-depth assumption in a new private
   `_span()` helper, and document that disabling Logfire's secret scrubber is a global,
   accepted-risk setting (matches `sh()`'s own WARNING about `cmd` leaking into spans).

</details>

<details>
<summary>Trajectory</summary>

1. Started from a plain request to instrument `deploy.py` with tracing. Explored OpenTelemetry
   SDK options in Python (raw `opentelemetry-sdk`, MLflow's tracing, Pydantic Logfire, Dagger's
   TUI, OpenLLMetry/OpenInference/OpenLIT for LLM-specific cases) and settled on Logfire for its
   minimal boilerplate, pretty local console trace tree, and standard-OTel-under-the-hood
   portability.
2. First implementation: `logfire.configure()` in `deploy.py`'s `main()`, `logfire.span()`
   wrapping `gha_log_group`/`sh()` in `src/rhoai_in_kind/__init__.py`. Hit an immediate API
   mismatch - `console=True` isn't valid (must be `None`/`False`/a `ConsoleOptions` object) -
   fixed by inspecting `logfire.configure`'s actual signature.
3. `logfire.instrument_boto3()` doesn't exist; Logfire has no built-in boto3/botocore
   instrumentor. Switched to `opentelemetry.instrumentation.botocore.BotocoreInstrumentor`
   directly (`opentelemetry-instrumentation-botocore` package - note: not `-boto3`, since boto3
   is a thin wrapper over botocore and that's the actual instrumented layer).
4. User wanted to view traces locally via IntelliJ's bundled OTel collector, which turned out to
   be gRPC-only. Discovered (by reading `logfire/_internal/config.py` directly) that Logfire's
   auto-added OTLP exporter is hardcoded to HTTP/protobuf and silently ignores
   `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` - built a manual gRPC exporter via
   `additional_span_processors`, popping the endpoint env vars beforehand so Logfire's own
   env-based auto-detection doesn't also add the incompatible HTTP one on top.
5. Explored trace viewers (Jaeger, otel-tui, .NET Aspire dashboard) and landed on the Aspire
   dashboard for its dual gRPC+HTTP OTLP support and clean UI - initially misremembered its
   ports as 4317/4318 (the generic OTel Collector convention), corrected after checking the
   actual container (`18888` UI, `18889` OTLP gRPC) and confirming reachability live via
   `docker exec kind-control-plane` TCP connect tests.
6. Found that every `gha_log_group`/`sh()` call was its own top-level span/trace with no shared
   parent - fixed by wrapping the whole run in one root span. Iterated through three
   implementations: manual `span.__enter__()`/`__exit__()` with a `try/finally` (working but
   verbose), then `@logfire.instrument` as a decorator (cleaner, since it handles entry/exit/
   exception status automatically and `extract_args=True` auto-attaches function arguments like
   `workbench_branch` as span attributes for free).
7. Discovered a real usability bug: `logfire.span("... {var} ...")`'s `{var}` syntax only
   expands into Logfire's own internal "message" attribute, not the literal OTel `span.name`
   field that generic viewers display - confirmed by reading `logfire/_internal/main.py`
   (`name=self._span_name`, used verbatim, defaulting to the *unexpanded* template). Also
   confirmed `@logfire.instrument`'s `span_name` is fixed once at decoration time, so it can
   never be dynamic - settled on keeping the span name static and relying on
   `extract_args=True`'s automatic per-call attribute capture instead of hand-rolling a
   `logfire.span()` call just for a dynamic name.
8. Ran `/code-review high latest commit` against the tracing commit. It surfaced three real
   issues, all verified against the actual code before fixing: (a) the t-string refactor had
   silently dropped `sh()`'s `print(f"$ {cmd}", ...)` echo, which mattered specifically for
   `capture_output=True` calls (subprocess.run swallows the child's own stdout in that case, so
   nothing was printed anywhere in CI); (b) the new `_span()` t-string helper's `code(4)`
   frame-depth lookup silently assumes exactly one level of wrapping (true only because `sh()`
   is its sole caller today) - marked it private and documented the assumption; (c)
   `scrubbing=False` disables Logfire's secret-redaction scrubber globally, not just for `sh()`'s
   `cmd` attribute as its adjacent WARNING comment might suggest - documented the actual scope.
9. User pointed out `subprocess.run()` only captures stdout when `capture_output=True` is
   explicitly passed - refined the restored echo to only fire in that case (gated behind
   `if capture_output:`), since non-capturing calls already have bash's own `set -x` trace
   visible in the inherited stdout regardless.
10. Live-tested the whole gRPC OTLP path against the running local kind cluster's own
    `kube-apiserver` (a separate, related piece of work on the same branch) by patching its
    static pod manifest in place via `docker cp` - confirmed no crashes/regressions from the
    Logfire changes while iterating on the collector-side setup.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced tracing for deployment operations and command execution.
  * Added detailed span information for shell commands and workflow log groups.
  * Added support for formatted template values in trace details.

* **Bug Fixes**
  * Improved command output handling with explicit capture and timeout controls.

* **Tests**
  * Added coverage for standard and debug-style template formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->